### PR TITLE
Configurable JS tracking token, backend tracking, fixes

### DIFF
--- a/app/code/community/Contactlab/Hub/Block/Adminhtml/System/Config/Field/Readonly.php
+++ b/app/code/community/Contactlab/Hub/Block/Adminhtml/System/Config/Field/Readonly.php
@@ -4,10 +4,9 @@ extends Mage_Adminhtml_Block_System_Config_Form_Field
 {
     protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
     {
-  //    die(var_dump($element));
-        $html = '<textarea id="'.$element->getHtmlId().'" readonly name="'.$element->getName().'" '.$element->serialize($element->getHtmlAttributes()).' >';
-        $html .= $element->getEscapedValue();
-        $html .= "</textarea>";
+        // The core <depends> tag functionality only works for fields containing proper input elements
+        $html = '<input id="'.$element->getHtmlId().'" hidden="hidden" />';
+        $html .= $element->getValue();
         $html .= $element->getAfterElementHtml();
         return $html;
     }

--- a/app/code/community/Contactlab/Hub/Block/Adminhtml/System/Config/Field/Readonly.php
+++ b/app/code/community/Contactlab/Hub/Block/Adminhtml/System/Config/Field/Readonly.php
@@ -1,0 +1,15 @@
+<?php 
+class Contactlab_Hub_Block_Adminhtml_System_Config_Field_Readonly
+extends Mage_Adminhtml_Block_System_Config_Form_Field
+{
+    protected function _getElementHtml(Varien_Data_Form_Element_Abstract $element)
+    {
+  //    die(var_dump($element));
+        $html = '<textarea id="'.$element->getHtmlId().'" readonly name="'.$element->getName().'" '.$element->serialize($element->getHtmlAttributes()).' >';
+        $html .= $element->getEscapedValue();
+        $html .= "</textarea>";
+        $html .= $element->getAfterElementHtml();
+        return $html;
+    }
+
+}

--- a/app/code/community/Contactlab/Hub/Helper/Data.php
+++ b/app/code/community/Contactlab/Hub/Helper/Data.php
@@ -1,51 +1,50 @@
 <?php
 /**
-* 
+*
 */
 class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
 {
     protected $_saveLog = false;
     protected $_logFilename = false;
 
-    public function __construct() 
+    public function __construct()
     {
         $this->_saveLog = $this->getConfigData('settings/log');
         $this->_logFilename = $this->getConfigData('settings/logfilename')?:'contactlabhub.log';
     }
 
-    public function getConfigData($key, $storeId=null)
+    public function getConfigData($key, $storeId = null)
     {
-		if(!$storeId)
-		{
-			$storeId = $this->getStore()->getStoreId();
-		}
-		return $this->getConfigStoredData($key, $storeId);
-	}
+        if (!$storeId) {
+            $storeId = $this->getStore()->getStoreId();
+        }
+        return $this->getConfigStoredData($key, $storeId);
+    }
 
-	public function getConfigStoredData($key, $storeId=null) 
-	{
-		return Mage::getStoreConfig('contactlab_hub/'.$key, $storeId);
-	}
+    public function getConfigStoredData($key, $storeId = null)
+    {
+        return Mage::getStoreConfig('contactlab_hub/'.$key, $storeId);
+    }
 
-	public function getConfigDefaultData($key) 
-	{
-		return Mage::getConfig()->getNode('default/contactlab_hub/'.$key);
-	}
+    public function getConfigDefaultData($key)
+    {
+        return Mage::getConfig()->getNode('default/contactlab_hub/'.$key);
+    }
 
-	public function setConfigData($path, $value, $scope='default', $scopeId=0) 
-	{		
-		Mage::getConfig()
+    public function setConfigData($path, $value, $scope = 'default', $scopeId = 0)
+    {
+        Mage::getConfig()
             ->saveConfig($path, $value, $scope, $scopeId)
             ->reinit();
-	
+    
         Mage::app()->reinitStores();
-	}
+    }
 
-	public function getStore()
-	{
-		return Mage::app()->getStore();
-	}
-	
+    public function getStore()
+    {
+        return Mage::app()->getStore();
+    }
+    
     /**
      * @param $message
      * @param null $level
@@ -53,261 +52,230 @@ class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
      *
      * @codeCoverageIgnore
      */
-	public function log($message, $level = null) 
-	{
-		if (!$this->_saveLog && $level == null) 
-		{
-			return false;
-		}
-		Mage::log($message, $level, $this->_logFilename);
-	}
-	
-	public function getJsConfigData()
-	{
-		$config = new stdClass();
-		$config->workspaceId = $this->getConfigData('settings/apiworkspaceid');
-		$config->nodeId = $this->getConfigData('settings/apinodeid');
-		$config->token = $this->getConfigData('settings/apitoken');
-		$config->context = 'ECOMMERCE';		
-		$contextInfo = new stdClass();
-		$store = new stdClass();
-		$store->id = "".Mage::app()->getStore()->getStoreId();
-		$store->name = Mage::app()->getStore()->getName();
-		$store->country = Mage::getStoreConfig('general/country/default');
-		$store->website = Mage::getUrl('', array('_store' => Mage::app()->getStore()->getStoreId()));
-		$store->type = "ECOMMERCE";
-		$contextInfo->store = $store;
-		$config->contextInfo = $contextInfo;
-		return "\nch('config', ".json_encode($config).");";
-	}
-	
-	public function getCustomer()
-	{
-		$customer = null;
-		if(Mage::getSingleton('customer/session')->isLoggedIn())
-		{
-			$customer = Mage::getModel('customer/customer')->load(Mage::getSingleton('customer/session')->getCustomer()->getId());
-		}
-		return $customer;
-	}
-	
-	protected function _getJsCoustomerInfo()
-	{
-		if(!$customer = $this->getCustomer())
-		{
-			return null;
-		}
-		$customerInfo = new stdClass();
-		$base = new stdClass();
-		$base->firstName = $customer->getFirstname();
-		$base->lastName = $customer->getLastname();
-		$contacts = new stdClass();
-		$contacts->email = $customer->getEmail();
-		$base->contacts = $contacts;
-		$customerInfo->base = $base;
-		return "\nch('customer',".json_encode($customerInfo).");";
-	}
-	
-	public function getCategoryPageTracking()
-	{
-		$category = Mage::registry('current_category');
-		$tracking = "";			
-		$evtName = 'events/viewedProductCategory';
-		if ($this->getConfigData($evtName)) 
-		{			
-			$searchQuery = Mage::app()->getRequest()->getParam('q');	
-			$currentLayer = Mage::registry('current_layer');
-			$searchResult = ($currentLayer instanceof Varien_Object)?$currentLayer->getProductCollection()->getAllIds():array();
-			$tracking.= "";				
-			$tracking.= $this->_getJsCoustomerInfo();
-			$categoryJs = new stdClass();
-			$categoryJs->type = 'viewedProductCategory';
-			$categoryJs->additionalProperties = false;
-			$properties = new stdClass();
-			$properties->category = $this->clearStrings($category->getName());
-			$categoryJs->properties = $properties;
-			$tracking.= "\nch('event',".json_encode($categoryJs).");";			
-		}
-		else 
-		{
-			$this->log($evtName.' OFF');
-		}
-		return $tracking;
-	}
-	
-	public function getProductPageTracking()
-	{
-		$tracking = "";			
-		$evtName = 'events/viewedProduct';
-		if ($this->getConfigData($evtName)) 
-		{
-			$product = Mage::registry('current_product');				
-			$categories = array();
-			foreach($product->getCategoryIds() as $categoryId)
-			{
-				$category = Mage::getModel('catalog/category')->load($categoryId);
-				$categories[] = $category->getName();
-			}
-			$tracking.= "";
-			$tracking.= $this->_getJsCoustomerInfo();
-			$productJs = new stdClass(); 
-			$productJs->type = 'viewedProduct';
-			$properties = new stdClass();
-			$properties->id = $product->getEntityId();
-			$properties->sku = $product->getSku();
-			$properties->name = $this->clearStrings($product->getName());
-			$properties->price = round($product->getFinalPrice(),2);			
-			$properties->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
-			$properties->linkUrl = $product->getProductUrl();
-			$properties->shortDescription = $this->clearStrings($product->getShortDescription());
-			$properties->category = $categories;
-			$productJs->properties = $properties;
-			$tracking.= "\nch('event',".json_encode($productJs).");";
-		}
-		else 
-		{
-			$this->log($evtName.' OFF');
-		}
-		return $tracking;
-	}
-	
-	public function getSearchTracking()
-	{		
-		$tracking = "";			
-		$evtName = 'events/searched';
-		if ($this->getConfigData($evtName)) 
-		{		
-			$searchJs = new stdClass();
-			$searchQuery = Mage::app()->getRequest()->getParam('q');	
-			$currentLayer = Mage::registry('current_layer');
-			$searchResult = ($currentLayer instanceof Varien_Object) ? count($currentLayer->getProductCollection()->getAllIds()) : 0;
-			$tracking.= "";
-			$tracking.= $this->_getJsCoustomerInfo();
-			$searchJs->type = 'searched';
-			$properties = new stdClass();
-			$properties->keyword = $this->clearStrings($searchQuery);
-			$properties->resultCount = $searchResult;
-			$searchJs->properties = $properties;
-			$tracking.= "\nch('event',".json_encode($searchJs).");";			
-		}
-		else 
-		{
-			$this->log($evtName.' OFF');
-		}
-		return $tracking;
-	}
-	
-	public function clearStrings($string) 
-	{
-		return trim(str_replace("''", "", str_replace("\n", " ",strip_tags($string))));
-		//return json_encode(str_replace(PHP_EOL, ' ', strip_tags(trim($string))));
-	}
-	
-	public function getUserAgent()
-	{
-		return isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
-	}
-	
-	public function getRemoteIpAddress()
-	{
-		return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
-	}
-	
-	public function sendAnonymousEvent() 
-	{
-		return (bool)$this->getConfigData('settings/send_anonymous');
-	}
-	
-	public function getExchangeRate($storeId=null)
-	{
-		$exchangeRate = 1;
-		$baseCurrency = $this->getConfigStoredData('events/base_currency', $storeId);
-		$websiteCurrency = $this->getConfigStoredData('events/website_currency', $storeId);		
-		if($baseCurrency != $websiteCurrency)
-		{
-			$exchangeRate = (float)$this->getConfigStoredData('events/exchange_rate', $storeId);
-			if(!$exchangeRate)
-			{
-				$exchangeRate = 1;
-			}
-		}		
-		return $exchangeRate;
-	}
-	
-	public function convertToBaseRate($price, $exchangeRate)
-	{
-		return round(((float)$price / $exchangeRate) ,2);
-	}
-	
-	public function getExtraProperties($customer)
-	{
-		$extraPropreties = array();				
-		for($i=1; $i<6; $i++)
-		{
-			$hubFixed = $this->getConfigStoredData('extra_properties/hub_fixed_'.$i);
-        	$magentoFixed = $this->getConfigStoredData('extra_properties/magento_fixed_'.$i);       	        	
-        	if($hubFixed && $magentoFixed)
-        	{
-        		$valueFixed = $this->_getCustomerAttributeValue($magentoFixed, $customer);
-        		$extraPropreties[$hubFixed] = $valueFixed; 
-        	}        	
-        	$hubVariable = $this->getConfigStoredData('extra_properties/hub_variable_'.$i);
-        	$magentoVariable = $this->getConfigStoredData('extra_properties/magento_variable_'.$i);
-        	if($hubVariable && $magentoVariable)
-        	{
-        		$valueVariable = $this->_getCustomerAttributeValue($magentoVariable, $customer);
-        		$extraPropreties[$hubVariable] = $valueVariable;
-        	}        	        	        
-		}
-		return $extraPropreties;
-	}
-	
-	protected function _getCustomerAttributeValue($attributeCode, $customer)
-	{		
-		$value = null;
-		
-		if($customer)
-		{
-			$attribute = Mage::getModel('eav/entity_attribute')->getCollection()->addFieldToFilter('attribute_code', array('in' => $attributeCode) )->getFirstItem();
-							
-			if($attribute)
-			{
-				if($attribute->getEntityTypeId() == 1)
-				{
-					if($attribute->getBackendType() == 'int')
-					{
-						$value = Mage::getResourceSingleton('customer/customer')
-						->getAttribute($attributeCode)
-						->getSource()
-						->getOptionText($customer->getData($attributeCode));				
-					}
-					else
-					{
-						$value = $customer->getData($attributeCode);
-					}				
-				}
-				else
-				{
-					/* BILLING INFORMATIONS */
-					$billing = $customer->getDefaultBillingAddress();
-					if($billing)
-					{
-						if($billing->getData($attributeCode))
-						{
-							if($attribute->getBackendType() == 'int')
-							{
-								$value = Mage::getResourceSingleton('customer/address')
-								->getAttribute($attributeCode)
-								->getSource()
-								->getOptionText($billing->getData($attributeCode));						
-							}
-							else
-							{
-								$value = $billing->getData($attributeCode);
-							}
-						}
-					}
-					/* SHIPPING INFORMATIONS 
+    public function log($message, $level = null)
+    {
+        if (!$this->_saveLog && $level == null) {
+            return false;
+        }
+        Mage::log($message, $level, $this->_logFilename);
+    }
+    
+    public function getJsConfigData()
+    {
+        $config = new stdClass();
+        $config->workspaceId = $this->getConfigData('settings/apiworkspaceid');
+        $config->nodeId = $this->getConfigData('settings/apinodeid');
+        $config->token = $this->getConfigData('settings/apitoken');
+        $config->context = 'ECOMMERCE';
+        $contextInfo = new stdClass();
+        $store = new stdClass();
+        $store->id = "".Mage::app()->getStore()->getStoreId();
+        $store->name = Mage::app()->getStore()->getName();
+        $store->country = Mage::getStoreConfig('general/country/default');
+        $store->website = Mage::getUrl('', array('_store' => Mage::app()->getStore()->getStoreId()));
+        $store->type = "ECOMMERCE";
+        $contextInfo->store = $store;
+        $config->contextInfo = $contextInfo;
+        return "\nch('config', ".json_encode($config).");";
+    }
+    
+    public function getCustomer()
+    {
+        $customer = null;
+        if (Mage::getSingleton('customer/session')->isLoggedIn()) {
+            $customer = Mage::getModel('customer/customer')->load(Mage::getSingleton('customer/session')->getCustomer()->getId());
+        }
+        return $customer;
+    }
+    
+    protected function _getJsCoustomerInfo()
+    {
+        if (!$customer = $this->getCustomer()) {
+            return null;
+        }
+        $customerInfo = new stdClass();
+        $base = new stdClass();
+        $base->firstName = $customer->getFirstname();
+        $base->lastName = $customer->getLastname();
+        $contacts = new stdClass();
+        $contacts->email = $customer->getEmail();
+        $base->contacts = $contacts;
+        $customerInfo->base = $base;
+        return "\nch('customer',".json_encode($customerInfo).");";
+    }
+    
+    public function getCategoryPageTracking()
+    {
+        $category = Mage::registry('current_category');
+        $tracking = "";
+        $evtName = 'events/viewedProductCategory';
+        if ($this->getConfigData($evtName)) {
+            $searchQuery = Mage::app()->getRequest()->getParam('q');
+            $currentLayer = Mage::registry('current_layer');
+            $searchResult = ($currentLayer instanceof Varien_Object)?$currentLayer->getProductCollection()->getAllIds():array();
+            $tracking.= "";
+            $tracking.= $this->_getJsCoustomerInfo();
+            $categoryJs = new stdClass();
+            $categoryJs->type = 'viewedProductCategory';
+            $categoryJs->additionalProperties = false;
+            $properties = new stdClass();
+            $properties->category = $this->clearStrings($category->getName());
+            $categoryJs->properties = $properties;
+            $tracking.= "\nch('event',".json_encode($categoryJs).");";
+        } else {
+            $this->log($evtName.' OFF');
+        }
+        return $tracking;
+    }
+    
+    public function getProductPageTracking()
+    {
+        $tracking = "";
+        $evtName = 'events/viewedProduct';
+        if ($this->getConfigData($evtName)) {
+            $product = Mage::registry('current_product');
+            $categories = array();
+            foreach ($product->getCategoryIds() as $categoryId) {
+                $category = Mage::getModel('catalog/category')->load($categoryId);
+                $categories[] = $category->getName();
+            }
+            $tracking.= "";
+            $tracking.= $this->_getJsCoustomerInfo();
+            $productJs = new stdClass();
+            $productJs->type = 'viewedProduct';
+            $properties = new stdClass();
+            $properties->id = $product->getEntityId();
+            $properties->sku = $product->getSku();
+            $properties->name = $this->clearStrings($product->getName());
+            $properties->price = round($product->getFinalPrice(), 2);
+            $properties->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
+            $properties->linkUrl = $product->getProductUrl();
+            $properties->shortDescription = $this->clearStrings($product->getShortDescription());
+            $properties->category = $categories;
+            $productJs->properties = $properties;
+            $tracking.= "\nch('event',".json_encode($productJs).");";
+        } else {
+            $this->log($evtName.' OFF');
+        }
+        return $tracking;
+    }
+    
+    public function getSearchTracking()
+    {
+        $tracking = "";
+        $evtName = 'events/searched';
+        if ($this->getConfigData($evtName)) {
+            $searchJs = new stdClass();
+            $searchQuery = Mage::app()->getRequest()->getParam('q');
+            $currentLayer = Mage::registry('current_layer');
+            $searchResult = ($currentLayer instanceof Varien_Object) ? count($currentLayer->getProductCollection()->getAllIds()) : 0;
+            $tracking.= "";
+            $tracking.= $this->_getJsCoustomerInfo();
+            $searchJs->type = 'searched';
+            $properties = new stdClass();
+            $properties->keyword = $this->clearStrings($searchQuery);
+            $properties->resultCount = $searchResult;
+            $searchJs->properties = $properties;
+            $tracking.= "\nch('event',".json_encode($searchJs).");";
+        } else {
+            $this->log($evtName.' OFF');
+        }
+        return $tracking;
+    }
+    
+    public function clearStrings($string)
+    {
+        return trim(str_replace("''", "", str_replace("\n", " ", strip_tags($string))));
+        //return json_encode(str_replace(PHP_EOL, ' ', strip_tags(trim($string))));
+    }
+    
+    public function getUserAgent()
+    {
+        return isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : '';
+    }
+    
+    public function getRemoteIpAddress()
+    {
+        return isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '';
+    }
+    
+    public function sendAnonymousEvent()
+    {
+        return (bool)$this->getConfigData('settings/send_anonymous');
+    }
+    
+    public function getExchangeRate($storeId = null)
+    {
+        $exchangeRate = 1;
+        $baseCurrency = $this->getConfigStoredData('events/base_currency', $storeId);
+        $websiteCurrency = $this->getConfigStoredData('events/website_currency', $storeId);
+        if ($baseCurrency != $websiteCurrency) {
+            $exchangeRate = (float)$this->getConfigStoredData('events/exchange_rate', $storeId);
+            if (!$exchangeRate) {
+                $exchangeRate = 1;
+            }
+        }
+        return $exchangeRate;
+    }
+    
+    public function convertToBaseRate($price, $exchangeRate)
+    {
+        return round(((float)$price / $exchangeRate), 2);
+    }
+    
+    public function getExtraProperties($customer)
+    {
+        $extraPropreties = array();
+        for ($i=1; $i<6; $i++) {
+            $hubFixed = $this->getConfigStoredData('extra_properties/hub_fixed_'.$i);
+            $magentoFixed = $this->getConfigStoredData('extra_properties/magento_fixed_'.$i);
+            if ($hubFixed && $magentoFixed) {
+                $valueFixed = $this->_getCustomerAttributeValue($magentoFixed, $customer);
+                $extraPropreties[$hubFixed] = $valueFixed;
+            }
+            $hubVariable = $this->getConfigStoredData('extra_properties/hub_variable_'.$i);
+            $magentoVariable = $this->getConfigStoredData('extra_properties/magento_variable_'.$i);
+            if ($hubVariable && $magentoVariable) {
+                $valueVariable = $this->_getCustomerAttributeValue($magentoVariable, $customer);
+                $extraPropreties[$hubVariable] = $valueVariable;
+            }
+        }
+        return $extraPropreties;
+    }
+    
+    protected function _getCustomerAttributeValue($attributeCode, $customer)
+    {
+        $value = null;
+        
+        if ($customer) {
+            $attribute = Mage::getModel('eav/entity_attribute')->getCollection()->addFieldToFilter('attribute_code', array('in' => $attributeCode) )->getFirstItem();
+                            
+            if ($attribute) {
+                if ($attribute->getEntityTypeId() == 1) {
+                    if ($attribute->getBackendType() == 'int') {
+                        $value = Mage::getResourceSingleton('customer/customer')
+                        ->getAttribute($attributeCode)
+                        ->getSource()
+                        ->getOptionText($customer->getData($attributeCode));
+                    } else {
+                        $value = $customer->getData($attributeCode);
+                    }
+                } else {
+                    /* BILLING INFORMATIONS */
+                    $billing = $customer->getDefaultBillingAddress();
+                    if ($billing) {
+                        if ($billing->getData($attributeCode)) {
+                            if ($attribute->getBackendType() == 'int') {
+                                $value = Mage::getResourceSingleton('customer/address')
+                                ->getAttribute($attributeCode)
+                                ->getSource()
+                                ->getOptionText($billing->getData($attributeCode));
+                            } else {
+                                $value = $billing->getData($attributeCode);
+                            }
+                        }
+                    }
+                    /* SHIPPING INFORMATIONS
 					$shipping = $customer->getDefaultShippingAddress();
 					if($shipping)
 					{
@@ -327,9 +295,9 @@ class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
 						}
 					}
 					*/
-				}		
-			}
-		}
-		return $value;
-	}
+                }
+            }
+        }
+        return $value;
+    }
 }

--- a/app/code/community/Contactlab/Hub/Helper/Data.php
+++ b/app/code/community/Contactlab/Hub/Helper/Data.php
@@ -76,6 +76,11 @@ class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
     public function getApiTokenForJavascript() {
         return Mage::getStoreConfig(self::JS_UNTRUSTED_TOKEN_CONFIG_PATH) ?: $this->getConfigData('settings/apitoken');
     }
+
+    public function deleteTrackingCookie() {
+        Mage::getSingleton('core/cookie')->set('_ch', '', -1, '/', '');
+        unset($_COOKIE['_ch']);
+    }
     
     public function getJsConfigData()
     {

--- a/app/code/community/Contactlab/Hub/Helper/Data.php
+++ b/app/code/community/Contactlab/Hub/Helper/Data.php
@@ -4,6 +4,8 @@
 */
 class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    const JS_TRACKING_ENABLED_CONFIG_PATH = 'contactlab_hub/js_tracking/enabled';
+
     protected $_saveLog = false;
     protected $_logFilename = false;
 
@@ -58,6 +60,13 @@ class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
             return false;
         }
         Mage::log($message, $level, $this->_logFilename);
+    }
+
+    /*
+    * @return bool
+    */
+    public function isJsTrackingEnabled() {
+        return Mage::getStoreConfigFlag(self::JS_TRACKING_ENABLED_CONFIG_PATH);
     }
     
     public function getJsConfigData()

--- a/app/code/community/Contactlab/Hub/Helper/Data.php
+++ b/app/code/community/Contactlab/Hub/Helper/Data.php
@@ -63,23 +63,42 @@ class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
         Mage::log($message, $level, $this->_logFilename);
     }
 
-    /*
+    /**
     * @return bool
     */
-    public function isJsTrackingEnabled() {
+    public function isJsTrackingEnabled()
+    {
         return Mage::getStoreConfigFlag(self::JS_TRACKING_ENABLED_CONFIG_PATH);
     }
 
-    /*
+    /**
     * @return bool
     */
-    public function getApiTokenForJavascript() {
+    public function getApiTokenForJavascript()
+    {
         return Mage::getStoreConfig(self::JS_UNTRUSTED_TOKEN_CONFIG_PATH) ?: $this->getConfigData('settings/apitoken');
     }
 
-    public function deleteTrackingCookie() {
+    public function deleteTrackingCookie()
+    {
         Mage::getSingleton('core/cookie')->set('_ch', '', -1, '/', '');
         unset($_COOKIE['_ch']);
+    }
+
+    /**
+    * Creates a tracking cookie, used when JS tracking is disabled.
+    * @return string
+    */
+    public function createTrackingCookie()
+    {
+        $cookieData = array('sid' => uniqid());
+        $customer = $this->getCustomer();
+        if ($customer != null) {
+            $cookieData['customerId'] = $customer->getId();
+        }
+        Mage::getModel('core/cookie')->set('_ch', json_encode($cookieData), 31536000, '/', '');
+        
+        return $cookieData['sid'];
     }
     
     public function getJsConfigData()

--- a/app/code/community/Contactlab/Hub/Helper/Data.php
+++ b/app/code/community/Contactlab/Hub/Helper/Data.php
@@ -5,6 +5,7 @@
 class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
 {
     const JS_TRACKING_ENABLED_CONFIG_PATH = 'contactlab_hub/js_tracking/enabled';
+    const JS_UNTRUSTED_TOKEN_CONFIG_PATH = 'contactlab_hub/js_tracking/untrusted_token';
 
     protected $_saveLog = false;
     protected $_logFilename = false;
@@ -68,13 +69,20 @@ class Contactlab_Hub_Helper_Data extends Mage_Core_Helper_Abstract
     public function isJsTrackingEnabled() {
         return Mage::getStoreConfigFlag(self::JS_TRACKING_ENABLED_CONFIG_PATH);
     }
+
+    /*
+    * @return bool
+    */
+    public function getApiTokenForJavascript() {
+        return Mage::getStoreConfig(self::JS_UNTRUSTED_TOKEN_CONFIG_PATH) ?: $this->getConfigData('settings/apitoken');
+    }
     
     public function getJsConfigData()
     {
         $config = new stdClass();
         $config->workspaceId = $this->getConfigData('settings/apiworkspaceid');
         $config->nodeId = $this->getConfigData('settings/apinodeid');
-        $config->token = $this->getConfigData('settings/apitoken');
+        $config->token = $this->getApiTokenForJavascript();
         $config->context = 'ECOMMERCE';
         $contextInfo = new stdClass();
         $store = new stdClass();

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -93,9 +93,7 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
         if ($cookie && $cookie['sid']) {
             $this->setSessionId($cookie['sid']);
         } else if (!$this->_helper()->isJsTrackingEnabled()) {
-            $sid = uniqid();
-            $cookieModel->set('_ch', json_encode(array('sid' => $sid)), 31536000, '/', '');
-            $this->setSessionId($sid);
+            $this->setSessionId($this->_helper()->createTrackingCookie());
         }
         
         if (!$this->getSessionId()) {

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -86,14 +86,22 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
     }
     
     protected function _getSid()
-    {
-        $cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'), true);
+    {   
+        $cookieModel = Mage::getModel('core/cookie');
+        $cookie = json_decode($cookieModel->get('_ch'), true);
 
         if ($cookie && $cookie['sid']) {
             $this->setSessionId($cookie['sid']);
-        } else {
+        } else if (!$this->_helper()->isJsTrackingEnabled()) {
+            $sid = uniqid();
+            $cookieModel->set('_ch', json_encode(array('sid' => $sid)), 31536000, '/', '');
+            $this->setSessionId($sid);
+        }
+        
+        if (!$this->getSessionId()) {
             $this->_helper()->log('Cookie disabled');
         }
+
         return $this->getSessionId();
     }
     
@@ -125,7 +133,7 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
         return $this->_hub;
     }
 
-    protected function _createUpdateCustomer()
+    public function _createUpdateCustomer()
     {
         $this->_helper()->log(__METHOD__);
         

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -205,18 +205,23 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
     protected function _getObjProduct($product_id)
     {
         $product = Mage::getModel('catalog/product')->load($product_id);
+        return $this->_toHubProduct($product);
+    }
+
+    protected function _toHubProduct(Mage_Catalog_Model_Product $product) {
         $objProduct = new stdClass();
-        if ($product) {
-            $objProduct->id = $product->getEntityId();
-            $objProduct->sku = $product->getSku();
-            $objProduct->name = $product->getName();
-            $objProduct->price = (float)Mage::getModel('directory/currency')->formatTxt($product->getPrice(), array( 'display' => Zend_Currency::NO_SYMBOL ));
-            $objProduct->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
-            $objProduct->linkUrl = Mage::getUrl($product->getUrlPath());
-            ;
-            $objProduct->shortDescription = $product->getShortDescription();
-            $objProduct->category = $this->_getCategoryNamesFromIds($product->getCategoryIds());
+        if ($product == null) {
+            return $objProduct;
         }
+        $objProduct->id = $product->getEntityId();
+        $objProduct->sku = $product->getSku();
+        $objProduct->name = $product->getName();
+        $objProduct->price = (float)Mage::getModel('directory/currency')->formatTxt($product->getPrice(), array( 'display' => Zend_Currency::NO_SYMBOL ));
+        $objProduct->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
+        $objProduct->linkUrl = Mage::getUrl($product->getUrlPath());
+        $objProduct->shortDescription = $product->getShortDescription();
+        $objProduct->category = $this->_getCategoryNamesFromIds($product->getCategoryIds());
+
         return $objProduct;
     }
     

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -219,7 +219,7 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
         $objProduct->price = (float)Mage::getModel('directory/currency')->formatTxt($product->getPrice(), array( 'display' => Zend_Currency::NO_SYMBOL ));
         $objProduct->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
         $objProduct->linkUrl = Mage::getUrl($product->getUrlPath());
-        $objProduct->shortDescription = $product->getShortDescription();
+        $objProduct->shortDescription = $product->getShortDescription() ?: "";
         $objProduct->category = $this->_getCategoryNamesFromIds($product->getCategoryIds());
 
         return $objProduct;

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -1,384 +1,318 @@
 <?php
 class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
 {
-	
-	const CONTACTLAB_HUB_STATUS_TO_EXPORT	= 0;
-    const CONTACTLAB_HUB_STATUS_EXPORTED	= 1;
-    const CONTACTLAB_HUB_STATUS_PROCESSING	= 2;
-    const CONTACTLAB_HUB_STATUS_FAILED	    = 3;
+    
+    const CONTACTLAB_HUB_STATUS_TO_EXPORT   = 0;
+    const CONTACTLAB_HUB_STATUS_EXPORTED    = 1;
+    const CONTACTLAB_HUB_STATUS_PROCESSING  = 2;
+    const CONTACTLAB_HUB_STATUS_FAILED      = 3;
 
     protected $_helper;
-	protected $_hub;
-	protected $_unexportedEvents;
-	protected $_remoteCustomerHubId;
-	protected $_eventForHub;
-    protected $_ciao; 
+    protected $_hub;
+    protected $_unexportedEvents;
+    protected $_remoteCustomerHubId;
+    protected $_eventForHub;
+    protected $_ciao;
     
     protected function _construct()
     {
         $this->_init('contactlab_hub/event');
     }
 
-    
     protected function _helper()
     {
-        if (!$this->_helper) 
-        {
+        if (!$this->_helper) {
             $this->_helper = Mage::helper('contactlab_hub');
         }
         return $this->_helper;
     }
     
-    
     public function getUnexportedEvents($pageSize = null)
     {
-    	if(!$this->_unexportedEvents)
-    	{
-    		$collection = $this->getCollection()
-    					->addFieldToSelect('entity_id')
-    					->addFieldToSelect('model')
-    					->addFieldToFilter('status', array('eq' => self::CONTACTLAB_HUB_STATUS_TO_EXPORT));
-    		if($pageSize)
-    		{
-    			$collection->getSelect()->limit($pageSize);    			
-    		}
-    		$unexportedEvents = array();
-    		foreach ($collection as $event)
-    		{    			    			    			    			    			
-    			$unexportedEvents[] = Mage::getModel('contactlab_hub/event_'.$event->getModel())->load($event->getEntityId());    			    			
-    		}
-    		$this->_unexportedEvents = $unexportedEvents;
-    	}
-    	return $this->_unexportedEvents;
+        if (!$this->_unexportedEvents) {
+            $collection = $this->getCollection()
+                        ->addFieldToSelect('entity_id')
+                        ->addFieldToSelect('model')
+                        ->addFieldToFilter('status', array('eq' => self::CONTACTLAB_HUB_STATUS_TO_EXPORT));
+            if ($pageSize) {
+                $collection->getSelect()->limit($pageSize);
+            }
+            $unexportedEvents = array();
+            foreach ($collection as $event) {
+                $unexportedEvents[] = Mage::getModel('contactlab_hub/event_'.$event->getModel())->load($event->getEntityId());
+            }
+            $this->_unexportedEvents = $unexportedEvents;
+        }
+        return $this->_unexportedEvents;
     }
    
     public function trace()
     {
-    	$this->_helper()->log(__METHOD__);
-    	$this->_assignData();    	
-    	$websiteId = Mage::getModel('core/store')->load($this->getStoreId())->getWebsiteId();
-    	$customer = Mage::getModel("customer/customer")->setWebsiteId($websiteId)->loadByEmail($this->getIdentityEmail());
-    	if ($this->_helper()->getConfigData('events/'.$this->getName(), $this->getStoreId()))
-    	{    		    		    	    		
-	    	if($customer || $this->_helper()->sendAnonymousEvent())
-	    	{    
-	    		$this->save();		    	
-	    	}
-	    	else
-	    	{
-	    		$this->_helper()->log('events/send anonymous events OFF');
-	    	}
-    	}
-    	else 
-    	{    		
-    		$this->_helper()->log($this->getEntityId().' disbled');
-    	}
-    	return $this;
+        $this->_helper()->log(__METHOD__);
+        $this->_assignData();
+        $websiteId = Mage::getModel('core/store')->load($this->getStoreId())->getWebsiteId();
+        $customer = Mage::getModel("customer/customer")->setWebsiteId($websiteId)->loadByEmail($this->getIdentityEmail());
+        if ($this->_helper()->getConfigData('events/'.$this->getName(), $this->getStoreId())) {
+            if ($customer || $this->_helper()->sendAnonymousEvent()) {
+                $this->save();
+            } else {
+                $this->_helper()->log('events/send anonymous events OFF');
+            }
+        } else {
+            $this->_helper()->log($this->getEntityId().' disbled');
+        }
+        return $this;
     }
     
     
     public function export()
     {
-    	$this->_helper()->log(__METHOD__);	
-    	try
-    	{  
-    		$this->setStatus(self::CONTACTLAB_HUB_STATUS_PROCESSING);    	    	
-	    	$this->_createUpdateCustomer();
-    		$hubEvent = $this->_composeHubEvent();     		
-    		$this->_getHub()->createEvent($hubEvent);
-    		$this->setHubEvent(json_encode($hubEvent));
-    		$this->setExportedDate(date('Y-m-d H:i:s'));
-    		$this->setStatus(self::CONTACTLAB_HUB_STATUS_EXPORTED);    	    		
-    		$this->save();    		    	
-    	}    	
+        $this->_helper()->log(__METHOD__);
+        try {
+            $this->setStatus(self::CONTACTLAB_HUB_STATUS_PROCESSING);
+            $this->_createUpdateCustomer();
+            $hubEvent = $this->_composeHubEvent();
+            $this->_getHub()->createEvent($hubEvent);
+            $this->setHubEvent(json_encode($hubEvent));
+            $this->setExportedDate(date('Y-m-d H:i:s'));
+            $this->setStatus(self::CONTACTLAB_HUB_STATUS_EXPORTED);
+            $this->save();
+        } catch (exception $e) {
+            $this->setStatus(self::CONTACTLAB_HUB_STATUS_FAILED);
+            $this->save();
+            $this->_helper()->log($e->getMessage());
+        }
 
-    	catch (exception $e)
-    	{    		
-    		$this->setStatus(self::CONTACTLAB_HUB_STATUS_FAILED);
-    		$this->save();    		    		
-    		$this->_helper()->log($e->getMessage());
-    	}     	
-
-    	$this->_helper()->log('fine export event');
-    	return $this;
+        $this->_helper()->log('fine export event');
+        return $this;
     }
-    
     
     protected function _getSid()
     {
-    	$cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'));
-    	if($cookie->sid)
-    	{
-    		$this->setSessionId($cookie->sid);
-    	}
-    	else
-    	{
-    		$this->_helper()->log('Cookie disabled');    		
-    	}
-    	return $this->getSessionId();
+        $cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'));
+        if ($cookie->sid) {
+            $this->setSessionId($cookie->sid);
+        } else {
+            $this->_helper()->log('Cookie disabled');
+        }
+        return $this->getSessionId();
     }
-    
     
     protected function _assignData()
-    {    	    	    	
-    	
-    	$this->setCreatedAt(date('Y-m-d H:i:s'))
-    		->setEnvUserAgent($this->_helper()->getUserAgent());    		  	
-    		
-    	if(!$this->getEnvRemoteIp())
-    	{
-    		$this->setEnvRemoteIp($this->_helper()->getRemoteIpAddress());
-    	}		
-    	if(!$this->getNeedUpdateIdentity())
-    	{
-    		$this->setNeedUpdateIdentity(false);
-    	}
-    	if(!$this->getStoreId())
-    	{
-    		$this->setStoreId(Mage::app()->getStore()->getStoreId());
-    	}    		
-    	if($customer = $this->_helper()->getCustomer())
-    	{
-    		$this->setIdentityEmail($customer->getEmail());
-    	}
-    	return $this;
+    {   
+        $this->setCreatedAt(date('Y-m-d H:i:s'))
+            ->setEnvUserAgent($this->_helper()->getUserAgent());
+            
+        if (!$this->getEnvRemoteIp()) {
+            $this->setEnvRemoteIp($this->_helper()->getRemoteIpAddress());
+        }
+        if (!$this->getNeedUpdateIdentity()) {
+            $this->setNeedUpdateIdentity(false);
+        }
+        if (!$this->getStoreId()) {
+            $this->setStoreId(Mage::app()->getStore()->getStoreId());
+        }
+        if ($customer = $this->_helper()->getCustomer()) {
+            $this->setIdentityEmail($customer->getEmail());
+        }
+        return $this;
     }
-    
     
     protected function _getHub()
     {
-    	if(!$this->_hub)
-    	{
-    		$this->_hub = Mage::getModel('contactlab_hub/hub')->setStoreId($this->getStoreId());
-    	}
-    	return $this->_hub;
+        if (!$this->_hub) {
+            $this->_hub = Mage::getModel('contactlab_hub/hub')->setStoreId($this->getStoreId());
+        }
+        return $this->_hub;
     }
 
-    
     protected function _createUpdateCustomer()
     {
-    	$this->_helper()->log(__METHOD__);
-    	
-    	$this->_remoteCustomerHubId = null;
-    	if($this->getNeedUpdateIdentity())
-    	{    		
-    		$customerData = $this->_getCustomerDataForHub();
-    		$remoteCustomerHubId = $this->_getRemoteCustomerHub($customerData);
-    		if($remoteCustomerHubId)
-    		{
-    			$this->_remoteCustomerHubId = $remoteCustomerHubId;  
-    			$customerData->id = $remoteCustomerHubId;
-    			if($this->getSessionId())
-    			{
-    				$customerData->session = $this->getSessionId();
-    				$this->_setRemoteCustomerHubSession($customerData);
-    			}    			
-    		}
-    	}       	    	
-    	return $this;
+        $this->_helper()->log(__METHOD__);
+        
+        $this->_remoteCustomerHubId = null;
+        if ($this->getNeedUpdateIdentity()) {
+            $customerData = $this->_getCustomerDataForHub();
+            $remoteCustomerHubId = $this->_getRemoteCustomerHub($customerData);
+            if ($remoteCustomerHubId) {
+                $this->_remoteCustomerHubId = $remoteCustomerHubId;
+                $customerData->id = $remoteCustomerHubId;
+                if ($this->getSessionId()) {
+                    $customerData->session = $this->getSessionId();
+                    $this->_setRemoteCustomerHubSession($customerData);
+                }
+            }
+        }
+        return $this;
     }
     
-    
-	protected function _composeHubEvent()
-	{		
-    	if(!$this->_eventForHub)
-    	{
-    		$this->_eventForHub = new stdClass();
-    	}    	    	
-    	$this->_eventForHub->type = $this->getName();
-    	$this->_eventForHub->date = date(DATE_ISO8601, strtotime($this->getCreatedAt()));    	
-    	$this->_eventForHub->context = "ECOMMERCE";    	    	       	
-    	$store = Mage::getModel('core/store')->load($this->getStoreId());
-    	$contextInfo = new stdClass();
-    	$objStore = new stdClass();
-    	$objStore->id = "".$this->getStoreId();
-    	$objStore->name = $store->getName();
-    	$objStore->country = "".Mage::getStoreConfig('general/country/default', $this->getStoreId());
-    	$objStore->website = Mage::getUrl('', array('_store' => $this->getStoreId()));
-    	$objStore->type = "ECOMMERCE"; 
-    	$contextInfo->store = $objStore;
-    	$client = new stdClass();
-    	if($this->getEnvUserAgent())
-    	{    		
-    		$client->userAgent = "".$this->getEnvUserAgent();
-    	}
-    	if($this->getEnvRemoteIp())
-    	{
-    		$client->ip = "".$this->getEnvRemoteIp();
-    	}
-    	$contextInfo->client = $client;
-    	$this->_eventForHub->contextInfo = $contextInfo;
-    	
-    	if($this->_remoteCustomerHubId)
-    	{
-    		$this->_eventForHub->customerId = $this->_remoteCustomerHubId;
-    	}
-    	else
-    	{
-    		$bringBackProperties = new stdClass();
-    		$bringBackProperties->type = "SESSION_ID";
-    		$bringBackProperties->value = $this->getSessionId();
-    		$bringBackProperties->nodeId = $this->_helper()->getConfigData('settings/apinodeid', $this->getStoreId());
-    		$this->_eventForHub->bringBackProperties = $bringBackProperties;
-    	}    	
-    	return $this->_eventForHub;
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $this->_eventForHub->type = $this->getName();
+        $this->_eventForHub->date = date(DATE_ISO8601, strtotime($this->getCreatedAt()));
+        $this->_eventForHub->context = "ECOMMERCE";
+        $store = Mage::getModel('core/store')->load($this->getStoreId());
+        $contextInfo = new stdClass();
+        $objStore = new stdClass();
+        $objStore->id = "".$this->getStoreId();
+        $objStore->name = $store->getName();
+        $objStore->country = "".Mage::getStoreConfig('general/country/default', $this->getStoreId());
+        $objStore->website = Mage::getUrl('', array('_store' => $this->getStoreId()));
+        $objStore->type = "ECOMMERCE";
+        $contextInfo->store = $objStore;
+        $client = new stdClass();
+        if ($this->getEnvUserAgent()) {
+            $client->userAgent = "".$this->getEnvUserAgent();
+        }
+        if ($this->getEnvRemoteIp()) {
+            $client->ip = "".$this->getEnvRemoteIp();
+        }
+        $contextInfo->client = $client;
+        $this->_eventForHub->contextInfo = $contextInfo;
+        
+        if ($this->_remoteCustomerHubId) {
+            $this->_eventForHub->customerId = $this->_remoteCustomerHubId;
+        } else {
+            $bringBackProperties = new stdClass();
+            $bringBackProperties->type = "SESSION_ID";
+            $bringBackProperties->value = $this->getSessionId();
+            $bringBackProperties->nodeId = $this->_helper()->getConfigData('settings/apinodeid', $this->getStoreId());
+            $this->_eventForHub->bringBackProperties = $bringBackProperties;
+        }
+        return $this->_eventForHub;
     }
-    
     
     protected function _getCategoryNamesFromIds($catIds)
     {
-    	$result = array();
-    	foreach ($catIds as $catId) 
-    	{
-    		$_category = Mage::getModel('catalog/category')->load($catId);
-    		if ($_category) 
-    		{
-    			$result[] = $_category->getName();
-    		}    		
-    	}
-    	return $result;
+        $result = array();
+        foreach ($catIds as $catId) {
+            $_category = Mage::getModel('catalog/category')->load($catId);
+            if ($_category) {
+                $result[] = $_category->getName();
+            }
+        }
+        return $result;
     }
-    
     
     protected function _getObjProduct($product_id)
     {
-	    $product = Mage::getModel('catalog/product')->load($product_id);
-	    $objProduct = new stdClass();	    
-	    if($product)
-	    {
-		    $objProduct->id = $product->getEntityId();
-		    $objProduct->sku = $product->getSku();
-		    $objProduct->name = $product->getName();
-		    $objProduct->price = (float)Mage::getModel('directory/currency')->formatTxt($product->getPrice(), array( 'display' => Zend_Currency::NO_SYMBOL ));
-		    $objProduct->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
-		    $objProduct->linkUrl = Mage::getUrl($product->getUrlPath());;
-		    $objProduct->shortDescription = $product->getShortDescription();
-		    $objProduct->category = $this->_getCategoryNamesFromIds($product->getCategoryIds());
-	    }
-	    return $objProduct;
+        $product = Mage::getModel('catalog/product')->load($product_id);
+        $objProduct = new stdClass();
+        if ($product) {
+            $objProduct->id = $product->getEntityId();
+            $objProduct->sku = $product->getSku();
+            $objProduct->name = $product->getName();
+            $objProduct->price = (float)Mage::getModel('directory/currency')->formatTxt($product->getPrice(), array( 'display' => Zend_Currency::NO_SYMBOL ));
+            $objProduct->imageUrl = ''.Mage::helper('catalog/image')->init($product, 'image');
+            $objProduct->linkUrl = Mage::getUrl($product->getUrlPath());
+            ;
+            $objProduct->shortDescription = $product->getShortDescription();
+            $objProduct->category = $this->_getCategoryNamesFromIds($product->getCategoryIds());
+        }
+        return $objProduct;
     }
-    
     
     protected function _getRemoteCustomerHub($customerData)
     {
-    	$remoteCustomerHub = null;    
-    	if($this->getIdentityEmail())
-    	{
-    		$remoteCustomerHub = $this->_getHub()->getRemoteCustomerHub($customerData);
-	    	if ($remoteCustomerHub->id) 
-	    	{	    		
-	    		return $remoteCustomerHub->id;
-	    	}
-    	}    	
-    	return $remoteCustomerHub;
+        $remoteCustomerHub = null;
+        if ($this->getIdentityEmail()) {
+            $remoteCustomerHub = $this->_getHub()->getRemoteCustomerHub($customerData);
+            if ($remoteCustomerHub->id) {
+                return $remoteCustomerHub->id;
+            }
+        }
+        return $remoteCustomerHub;
     }
-    
     
     protected function _setRemoteCustomerHubSession($customerData)
     {
-    	$remoteCustomerHubSession = $this->_getHub()->setRemoteCustomerHubSession($customerData);
-    	return $this;
+        $remoteCustomerHubSession = $this->_getHub()->setRemoteCustomerHubSession($customerData);
+        return $this;
     }
     
     protected function _getCustomerDataForHub()
-   	{
-   		$customerData = new stdClass();
-   		$customerData->nodeId = $this->_helper()->getConfigData('settings/apinodeid', $this->getStoreId());
-   		$base = new stdClass();
-   		$contacts = new stdClass();
-   		$contacts->email = $this->getIdentityEmail();   	
-   		$base->contacts = $contacts;
-   		$locale = Mage::getStoreConfig('general/locale/code', $this->getStoreId());
-   		//$customerData->extra->locale = !empty($tmpval) ? $tmpval : '';
-   		if (!empty($locale)) 
-   		{
-   			$base->locale = $locale;
-   		}
-   		$websiteId = Mage::getModel('core/store')->load($this->getStoreId())->getWebsiteId();
-   		$customer = Mage::getModel("customer/customer")->setWebsiteId($websiteId)->loadByEmail($this->getIdentityEmail());
-   		if ($customer) 
-   		{   			
-   			if ($customer->getPrefix()) 
-   			{
-   				$base->title = $customer->getPrefix();
-   			}
-   			if ($customer->getFirstname()) 
-   			{
-   				$base->firstName = $customer->getFirstname();
-   			}
-   			if ($customer->getLastname()) 
-   			{
-   				$base->lastName = $customer->getLastname();
-   			}
-   			if ($customer->getGender())
-   			{
-   				$base->gender = $customer->getGender() == 1 ? 'Male' : 'Female';
-   			}   			
-   			if ($customer->getDob()) 
-   			{   				
-   				$base->dob = date('Y-m-d', strtotime($customer->getDob()));
-   			}
-   			$customerAddressId = $customer->getDefaultBilling();
-   			
-   			if (intval($customerAddressId)) 
-   			{   		
-   				$objAddress = new stdClass();
-   				$address = Mage::getModel('customer/address')->load($customerAddressId);
-   				if ($address->getCity()) 
-   				{
-   					$objAddress->city = $address->getCity();
-   				}
-   				$street = $address->getStreet();
-   				if (!empty($tmpval))
-   				{
-   					$tmpval = is_array($street) ? $street[0] : $street;
-   					$objAddress->street = $street ?: '';
-   				}
-   				if ($address->getRegion())
-   				{
-   					$objAddress->province = $address->getRegion();
-   				}
-   				if ($address->getPostcode()) 
-   				{
-   					$objAddress->zip = $address->getPostcode();
-   				}   				
-   				if ($address->getCountry()) 
-   				{
-   					$country = Mage::getModel('directory/country')->load($address->getCountry())->getName();
-   					$objAddress->country = $country ?: '';
-   				}
-   				$base->address = $objAddress;
-   			}   			   			
-   		}
-   		if(in_array($this->getName(), array('campaignSubscribed', 'campaignUnsubscribed')))
-   		{
-	   		$subscriber = Mage::getModel('newsletter/subscriber')->loadByEmail($this->getIdentityEmail());
-	   		if ($subscriber->getId()) 
-	   		{
-	   			$subcriberObj = new stdClass();
-	   			$subcriberObj->id = $this->_helper()->getConfigData('events/campaignName', $this->getStoreId());
-	   			$subcriberObj->kind = "DIGITAL_MESSAGE";
-	   			$tmpval = $subscriber->getData('subscriber_status') == Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED;
-	   			$subcriberObj->subscribed = $tmpval ? true : false;
-	   			$subcriberObj->subscriberId = $subscriber->getSubscriberId();
-	   			
-				$subcriberObj->updatedAt = date(DATE_ISO8601, strtotime($this->getCreatedAt()));
-				$subcriberObj->registeredAt = date(DATE_ISO8601, strtotime($subscriber->getCreatedAt()));
-				$subcriberObj->startDate = date(DATE_ISO8601, strtotime($subscriber->getLastSubscribedAt()));    			 
-	   			if($subcriberObj->subscribed)
-	   			{   		   				
-	   				$subcriberObj->endDate = null;
-	   			}
-	   			else
-	   			{      				
-	   				$subcriberObj->endDate = date(DATE_ISO8601, strtotime($this->getCreatedAt()));
-	   			}   			
-	   			$subscriptions[] = $subcriberObj;
-	   			$base->subscriptions = $subscriptions;   			
-	   		}   	
-   		}
-   		$customerData->base = $base;
-   		return $customerData;
-   	}   	
-   
+    {
+        $customerData = new stdClass();
+        $customerData->nodeId = $this->_helper()->getConfigData('settings/apinodeid', $this->getStoreId());
+        $base = new stdClass();
+        $contacts = new stdClass();
+        $contacts->email = $this->getIdentityEmail();
+        $base->contacts = $contacts;
+        $locale = Mage::getStoreConfig('general/locale/code', $this->getStoreId());
+        //$customerData->extra->locale = !empty($tmpval) ? $tmpval : '';
+        if (!empty($locale)) {
+            $base->locale = $locale;
+        }
+        $websiteId = Mage::getModel('core/store')->load($this->getStoreId())->getWebsiteId();
+        $customer = Mage::getModel("customer/customer")->setWebsiteId($websiteId)->loadByEmail($this->getIdentityEmail());
+        if ($customer) {
+            if ($customer->getPrefix()) {
+                $base->title = $customer->getPrefix();
+            }
+            if ($customer->getFirstname()) {
+                $base->firstName = $customer->getFirstname();
+            }
+            if ($customer->getLastname()) {
+                $base->lastName = $customer->getLastname();
+            }
+            if ($customer->getGender()) {
+                $base->gender = $customer->getGender() == 1 ? 'Male' : 'Female';
+            }
+            if ($customer->getDob()) {
+                $base->dob = date('Y-m-d', strtotime($customer->getDob()));
+            }
+            $customerAddressId = $customer->getDefaultBilling();
+            
+            if (intval($customerAddressId)) {
+                $objAddress = new stdClass();
+                $address = Mage::getModel('customer/address')->load($customerAddressId);
+                if ($address->getCity()) {
+                    $objAddress->city = $address->getCity();
+                }
+                $street = $address->getStreet();
+                if (!empty($tmpval)) {
+                    $tmpval = is_array($street) ? $street[0] : $street;
+                    $objAddress->street = $street ?: '';
+                }
+                if ($address->getRegion()) {
+                    $objAddress->province = $address->getRegion();
+                }
+                if ($address->getPostcode()) {
+                    $objAddress->zip = $address->getPostcode();
+                }
+                if ($address->getCountry()) {
+                    $country = Mage::getModel('directory/country')->load($address->getCountry())->getName();
+                    $objAddress->country = $country ?: '';
+                }
+                $base->address = $objAddress;
+            }
+        }
+        if (in_array($this->getName(), array('campaignSubscribed', 'campaignUnsubscribed'))) {
+            $subscriber = Mage::getModel('newsletter/subscriber')->loadByEmail($this->getIdentityEmail());
+            if ($subscriber->getId()) {
+                $subcriberObj = new stdClass();
+                $subcriberObj->id = $this->_helper()->getConfigData('events/campaignName', $this->getStoreId());
+                $subcriberObj->kind = "DIGITAL_MESSAGE";
+                $tmpval = $subscriber->getData('subscriber_status') == Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED;
+                $subcriberObj->subscribed = $tmpval ? true : false;
+                $subcriberObj->subscriberId = $subscriber->getSubscriberId();
+                
+                $subcriberObj->updatedAt = date(DATE_ISO8601, strtotime($this->getCreatedAt()));
+                $subcriberObj->registeredAt = date(DATE_ISO8601, strtotime($subscriber->getCreatedAt()));
+                $subcriberObj->startDate = date(DATE_ISO8601, strtotime($subscriber->getLastSubscribedAt()));
+                if ($subcriberObj->subscribed) {
+                    $subcriberObj->endDate = null;
+                } else {
+                    $subcriberObj->endDate = date(DATE_ISO8601, strtotime($this->getCreatedAt()));
+                }
+                $subscriptions[] = $subcriberObj;
+                $base->subscriptions = $subscriptions;
+            }
+        }
+        $customerData->base = $base;
+        return $customerData;
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -71,12 +71,12 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
             $this->_createUpdateCustomer();
             $hubEvent = $this->_composeHubEvent();
             $this->_getHub()->createEvent($hubEvent);
-            $this->setHubEvent(json_encode($hubEvent));
             $this->setExportedDate(date('Y-m-d H:i:s'));
             $this->setStatus(self::CONTACTLAB_HUB_STATUS_EXPORTED);
             $this->save();
         } catch (exception $e) {
             $this->setStatus(self::CONTACTLAB_HUB_STATUS_FAILED);
+            $this->setHubEvent(json_encode($hubEvent));
             $this->save();
             $this->_helper()->log($e->getMessage());
         }

--- a/app/code/community/Contactlab/Hub/Model/Event.php
+++ b/app/code/community/Contactlab/Hub/Model/Event.php
@@ -89,9 +89,10 @@ class Contactlab_Hub_Model_Event extends Mage_Core_Model_Abstract
     
     protected function _getSid()
     {
-        $cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'));
-        if ($cookie->sid) {
-            $this->setSessionId($cookie->sid);
+        $cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'), true);
+
+        if ($cookie && $cookie['sid']) {
+            $this->setSessionId($cookie['sid']);
         } else {
             $this->_helper()->log('Cookie disabled');
         }

--- a/app/code/community/Contactlab/Hub/Model/Event/AddToCart.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/AddToCart.php
@@ -1,36 +1,31 @@
 <?php
 class Contactlab_Hub_Model_Event_AddToCart extends Contactlab_Hub_Model_Event
 {
-	protected function _assignData()
-	{		
-		if(!$this->_getSid())
-		{
-			return;
-		}
-		$item = $this->getEvent()->getQuoteItem();
-		$product = $this->getEvent()->getProduct();		
-		if($product)
-		{
-			$eventData = array(
-							'product_id' => $product->getId(),
-							'qty' => $item->getQty()
-						);
-			$this->setName('addedProduct')
-				->setModel('addToCart')
-				->setEventData(json_encode($eventData));
-		}
-		return parent::_assignData();
-	}
-	
-	protected function _composeHubEvent()
-	{		
-		if(!$this->_eventForHub)
-		{
-			$this->_eventForHub = new stdClass();
-		}		
-		$eventData = json_decode($this->getEventData());		
-		$this->_eventForHub->properties = $this->_getObjProduct($eventData->product_id);
-		$this->_eventForHub->properties->quantity = $eventData->qty;
-		return parent::_composeHubEvent();
-	}
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+        $item = $this->getEvent()->getQuoteItem();
+        $product = $this->getEvent()->getProduct();
+
+        if ($product) {
+            $eventData = $this->_toHubProduct($product);
+            $eventData->quantity = $item->getQty();
+            
+            $this->setName('addedProduct')
+                ->setModel('addToCart')
+                ->setEventData(json_encode($eventData));
+        }
+        return parent::_assignData();
+    }
+    
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        return parent::_composeHubEvent();
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/AddToCompare.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/AddToCompare.php
@@ -1,31 +1,26 @@
 <?php
 class Contactlab_Hub_Model_Event_AddToCompare extends Contactlab_Hub_Model_Event
 {
-	protected function _assignData()
-	{				
-		if(!$this->_getSid())
-		{
-			return;
-		}
-		$product = $this->getEvent()->getProduct();				
-		$eventData = array(
-						'product_id' => $product->getId()
-					);
-		$this->setName('addedCompare')
-			->setModel('addToCompare')
-			->setEventData(json_encode($eventData));
-		
-		return parent::_assignData();
-	}
-	
-	protected function _composeHubEvent()
-	{
-		if(!$this->_eventForHub)
-		{
-			$this->_eventForHub = new stdClass();
-		}
-		$eventData = json_decode($this->getEventData());
-		$this->_eventForHub->properties = $this->_getObjProduct($eventData->product_id);
-		return parent::_composeHubEvent();
-	}
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+
+        $product = $this->getEvent()->getProduct();
+        $this->setName('addedCompare')
+            ->setModel('addToCompare')
+            ->setEventData(json_encode($this->_toHubProduct($product)));
+
+        return parent::_assignData();
+    }
+    
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        return parent::_composeHubEvent();
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/AddToWishlist.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/AddToWishlist.php
@@ -1,31 +1,26 @@
 <?php
 class Contactlab_Hub_Model_Event_AddToWishlist extends Contactlab_Hub_Model_Event
 {
-	protected function _assignData()
-	{				
-		if(!$this->_getSid())
-		{
-			return;
-		}
-		$product = $this->getEvent()->getItem()->getProduct();				
-		$eventData = array(
-						'product_id' => $product->getId()
-					);
-		$this->setName('addedWishlist')
-			->setModel('addToWishlist')
-			->setEventData(json_encode($eventData));
-		
-		return parent::_assignData();
-	}
-	
-	protected function _composeHubEvent()
-	{
-		if(!$this->_eventForHub)
-		{
-			$this->_eventForHub = new stdClass();
-		}
-		$eventData = json_decode($this->getEventData());
-		$this->_eventForHub->properties = $this->_getObjProduct($eventData->product_id);
-		return parent::_composeHubEvent();
-	}
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+        $product = $this->getEvent()->getItem()->getProduct();
+        $this->setName('addedWishlist')
+            ->setModel('addToWishlist')
+            ->setEventData(json_encode($this->_toHubProduct($product)));
+        
+        return parent::_assignData();
+    }
+    
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $eventData = json_decode($this->getEventData());
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        return parent::_composeHubEvent();
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/RemoveToCart.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/RemoveToCart.php
@@ -1,22 +1,19 @@
 <?php
 class Contactlab_Hub_Model_Event_RemoveToCart extends Contactlab_Hub_Model_Event_AddToCart
 {
-	protected function _assignData()
-	{	
-		if(!$this->_getSid())
-		{
-			return;
-		}
-		$item = $this->getEvent()->getQuoteItem();
-		$product = $item->getProduct();				
-		$eventData = array(
-						'product_id' => $product->getId(),
-						'qty' => $item->getQty()
-					);
-		$this->setName('removedProduct')
-			->setModel('removeToCart')
-			->setEventData(json_encode($eventData));		
-		return Contactlab_Hub_Model_Event::_assignData();
-	}
-	
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+        $item = $this->getEvent()->getQuoteItem();
+        $product = $item->getProduct();
+        $eventData = $this->_toHubProduct($product);
+        $eventData->quantity = $item->getQty();
+
+        $this->setName('removedProduct')
+            ->setModel('removeToCart')
+            ->setEventData(json_encode($eventData));
+        return Contactlab_Hub_Model_Event::_assignData();
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/RemoveToCompare.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/RemoveToCompare.php
@@ -1,20 +1,21 @@
 <?php
 class Contactlab_Hub_Model_Event_RemoveToCompare extends Contactlab_Hub_Model_Event_AddToCompare
 {
-	protected function _assignData()
-	{				
-		if(!$this->_getSid())
-		{
-			return;
-		}	
-		$product = $this->getEvent()->getProduct();				
-		$eventData = array(
-						'product_id' => $product->getId()
-					);
-		$this->setName('removedCompare')
-			->setModel('removeToCompare')
-			->setEventData(json_encode($eventData));
-		
-		return Contactlab_Hub_Model_Event::_assignData();
-	}
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+
+        // This is actually a Mage_Catalog_Model_Product_Compare_Item object
+        $product = $this->getEvent()->getProduct();
+        $eventData = array(
+                        'product_id' => $product->getProductId()
+                    );
+        $this->setName('removedCompare')
+            ->setModel('removeToCompare')
+            ->setEventData(json_encode($eventData));
+        
+        return Contactlab_Hub_Model_Event::_assignData();
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/RemoveToCompare.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/RemoveToCompare.php
@@ -1,5 +1,5 @@
 <?php
-class Contactlab_Hub_Model_Event_RemoveToCompare extends Contactlab_Hub_Model_Event_AddToCompare
+class Contactlab_Hub_Model_Event_RemoveToCompare extends Contactlab_Hub_Model_Event
 {
     protected function _assignData()
     {
@@ -16,6 +16,15 @@ class Contactlab_Hub_Model_Event_RemoveToCompare extends Contactlab_Hub_Model_Ev
             ->setModel('removeToCompare')
             ->setEventData(json_encode($eventData));
         
-        return Contactlab_Hub_Model_Event::_assignData();
+        return parent::_assignData();
+    }
+
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        return parent::_composeHubEvent();
     }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/RemoveToWishlist.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/RemoveToWishlist.php
@@ -9,12 +9,9 @@ class Contactlab_Hub_Model_Event_RemoveToWishlist extends Contactlab_Hub_Model_E
 		}
 		$item = $this->getEvent()->getData('data_object');
     	$product = $item->getProduct();				
-		$eventData = array(
-						'product_id' => $product->getId()
-					);
 		$this->setName('removedWishlist')
 			->setModel('removeToWishlist')
-			->setEventData(json_encode($eventData));
+			->setEventData(json_encode($this->_toHubProduct($product)));
 		
 		return Contactlab_Hub_Model_Event::_assignData();
 	}

--- a/app/code/community/Contactlab/Hub/Model/Event/RemoveToWishlist.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/RemoveToWishlist.php
@@ -1,5 +1,5 @@
 <?php
-class Contactlab_Hub_Model_Event_RemoveToWishlist extends Contactlab_Hub_Model_Event_AddToWishlist
+class Contactlab_Hub_Model_Event_RemoveToWishlist extends Contactlab_Hub_Model_Event
 {
 	protected function _assignData()
 	{						
@@ -13,7 +13,16 @@ class Contactlab_Hub_Model_Event_RemoveToWishlist extends Contactlab_Hub_Model_E
 			->setModel('removeToWishlist')
 			->setEventData(json_encode($this->_toHubProduct($product)));
 		
-		return Contactlab_Hub_Model_Event::_assignData();
-	}
-	
+		return parent::_assignData();
+    }
+
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $eventData = json_decode($this->getEventData());
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        return parent::_composeHubEvent();
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/Searched.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/Searched.php
@@ -1,0 +1,30 @@
+<?php
+class Contactlab_Hub_Model_Event_Searched extends Contactlab_Hub_Model_Event
+{
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+        $properties = new stdClass();
+        $properties->keyword = $this->_helper()->clearStrings(Mage::app()->getRequest()->getParam('q'));
+
+        $currentLayer = Mage::registry('current_layer');
+        $properties->resultCount = ($currentLayer instanceof Varien_Object) ? count($currentLayer->getProductCollection()->getAllIds()) : 0;
+
+        $this->setName('searched')
+            ->setModel('Searched')
+            ->setEventData(json_encode($properties));
+
+        return parent::_assignData();
+    }
+    
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        return parent::_composeHubEvent();
+    }
+}

--- a/app/code/community/Contactlab/Hub/Model/Event/ViewedProduct.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/ViewedProduct.php
@@ -9,7 +9,7 @@ class Contactlab_Hub_Model_Event_ViewedProduct extends Contactlab_Hub_Model_Even
         $product = Mage::registry('current_product');
         $this->setName('viewedProduct')
             ->setModel('ViewedProduct')
-            ->setEventData(json_encode($this->_getObjProduct($product->getId())));
+            ->setEventData(json_encode($this->_toHubProduct($product)));
 
         return parent::_assignData();
     }

--- a/app/code/community/Contactlab/Hub/Model/Event/ViewedProduct.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/ViewedProduct.php
@@ -1,0 +1,28 @@
+<?php
+class Contactlab_Hub_Model_Event_ViewedProduct extends Contactlab_Hub_Model_Event
+{
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+        $product = Mage::registry('current_product');
+        $eventData = array('product_id' => $product->getId());
+        $this->setName('viewedProduct')
+            ->setModel('ViewedProduct')
+            ->setEventData(json_encode($eventData));
+        
+
+        return parent::_assignData();
+    }
+    
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $eventData = json_decode($this->getEventData());
+        $this->_eventForHub->properties = $this->_getObjProduct($eventData->product_id);
+        return parent::_composeHubEvent();
+    }
+}

--- a/app/code/community/Contactlab/Hub/Model/Event/ViewedProduct.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/ViewedProduct.php
@@ -7,11 +7,9 @@ class Contactlab_Hub_Model_Event_ViewedProduct extends Contactlab_Hub_Model_Even
             return;
         }
         $product = Mage::registry('current_product');
-        $eventData = array('product_id' => $product->getId());
         $this->setName('viewedProduct')
             ->setModel('ViewedProduct')
-            ->setEventData(json_encode($eventData));
-        
+            ->setEventData(json_encode($this->_getObjProduct($product->getId())));
 
         return parent::_assignData();
     }
@@ -21,8 +19,7 @@ class Contactlab_Hub_Model_Event_ViewedProduct extends Contactlab_Hub_Model_Even
         if (!$this->_eventForHub) {
             $this->_eventForHub = new stdClass();
         }
-        $eventData = json_decode($this->getEventData());
-        $this->_eventForHub->properties = $this->_getObjProduct($eventData->product_id);
+        $this->_eventForHub->properties = json_decode($this->getEventData());
         return parent::_composeHubEvent();
     }
 }

--- a/app/code/community/Contactlab/Hub/Model/Event/ViewedProductCategory.php
+++ b/app/code/community/Contactlab/Hub/Model/Event/ViewedProductCategory.php
@@ -1,0 +1,31 @@
+<?php
+class Contactlab_Hub_Model_Event_ViewedProductCategory extends Contactlab_Hub_Model_Event
+{
+    protected function _assignData()
+    {
+        if (!$this->_getSid()) {
+            return;
+        }
+
+        $category = Mage::registry('current_category');
+        $eventData = array(
+            'category' => $this->_helper()->clearStrings($category->getName())
+        );
+
+        $this->setName('viewedProductCategory')
+            ->setModel('ViewedProductCategory')
+            ->setEventData(json_encode($eventData));
+
+        return parent::_assignData();
+    }
+    
+    protected function _composeHubEvent()
+    {
+        if (!$this->_eventForHub) {
+            $this->_eventForHub = new stdClass();
+        }
+        $this->_eventForHub->properties = json_decode($this->getEventData());
+        $event =  parent::_composeHubEvent();
+        return $event;
+    }
+}

--- a/app/code/community/Contactlab/Hub/Model/Hub.php
+++ b/app/code/community/Contactlab/Hub/Model/Hub.php
@@ -1,271 +1,249 @@
-<?php 
-class Contactlab_Hub_Model_Hub extends Mage_Core_Model_Abstract 
+<?php
+class Contactlab_Hub_Model_Hub extends Mage_Core_Model_Abstract
 {
-	const API_VERSION = 'hub/v1/workspaces/';
-	
-	
-	protected $_helper = null;		
-	
-	
-	protected function _getApiToken()
-	{
-		return $this->_helper()->getConfigData('settings/apitoken', $this->getStoreId());
-	}
-	
-	
-	protected function _getApiWorkspace()
-	{
-		return $this->_helper()->getConfigData('settings/apiworkspaceid', $this->getStoreId());
-	}
-	
-	
-	protected function _getNodeId()
-	{
-		$this->_helper()->getConfigData('settings/apinodeid', $this->getStoreId());
-	}
-	
-	
-	protected function _getApiProxy()
-	{
-		return $this->_helper()->getConfigData('settings/useproxy', $this->getStoreId()) ? $this->_helper()->getConfigData('settings/apiproxy', $this->getStoreId()) : false;
-	}
-	
-	
-	public function getRemoteCustomerHub($data)
-	{
-		$this->_helper()->log(__METHOD__);
-		try {
-			$response = $this->curlPost($this->_getApiUrl('customers'), json_encode($data), true);
-			$response = json_decode($response);
-			if ($response->curl_http_code == 409) 
-			{							
-				unset($data->nodeId);
-				$data->id = $response->data->customer->id;
-				//unset($data->subscriptions);
-				$response = $this->curlPost($response->data->customer->href, json_encode($data), true, null, "PATCH");
-				return json_decode($response);				
-			}			
-			else 
-			{				
-				return $response->id;
-			}
-		} catch (\Exception $e) {
-			throw $e;
-		}
-	}
-	
-	
-	public function setRemoteCustomerHubSession($data)
-	{
-		$this->_helper()->log(__METHOD__);					
-			$url = $this->_getApiUrl('customers').'/'.$data->id.'/sessions';
-			$session = $data->session;
-			$data = new stdClass();
-			$data->value = $session;
-			$response = $this->curlPost($url, json_encode($data), true);			
-			return json_decode($response);		
-	}
-	
-		
-	public function deleteCustomerByExternalId($externalId) 
-	{
-		$this->_helper()->log(__METHOD__);
-		try {
-			$result = $this->findCustomersByExternalId($externalId);
-			foreach ($result as $customer) {
-				$this->deleteCustomer($customer->id);
-			}
-		} catch (\Exception $e) {
-			throw $e;
-		}
-	}
-	
-	
-	public function deleteCustomer($id) 
-	{
-		$this->_helper()->log(__METHOD__);
-		try {
-			$response = $this->curlPost($this->_getApiUrl('customers/'.$id), null, true, null, 'DELETE');
-			return $response;
-		} catch (\Exception $e) {
-			throw $e;
-		}
-	}
-	
-	
-	public function createEvent($data) 
-	{
-		$this->_helper()->log(__METHOD__);		
-		try {
-			$response = $this->curlPost($this->_getApiUrl('events'), json_encode($data), true);
-			
-			return $response;
-		} catch (\Exception $e) {
-			throw $e;
-		}
-	}
-	
-		
-	public function getAllCustomers($outputAssoc = false)
-	{
-		$result = null;
-		try {
-			$response = $this->curlGet($this->_getApiUrl('customers'), ['nodeId' => $this->_getNodeId(), 'size' => 20]);
-			$response = json_decode($response, true);
-			//return $response;
-			if (!$response) {
-			 	throw new \Exception('empty response', 664);
-			}
-			if (!isset($response['_embedded']['customers']) || !is_array($response['_embedded']['customers'])) {
-			 	throw new \Exception('not valid response', 663);
-		 	}		
-			$result = $response['_embedded']['customers'];
-		} catch (\Exception $e) {
-			throw $e;
-		}
-		//if (count($result) > 0) {
-		return $result;
-		//}
-		//return null;
-	}
-	 
-	
-	private function _helper()
-	{
-		if ($this->_helper == null) {
-			$this->_helper = Mage::helper('contactlab_hub');
-		}
-		return $this->_helper;
-	}	
-	
-	
-	private function _getApiUrl($actionUrl) 
-	{		
-		$apiUrl = $this->_helper()->getConfigData('settings/apiurl', $this->getStoreId());
-		if (substr($apiUrl, -1) != '/')
-		{
-			$apiUrl .= '/';
-		}
-		
-		//return $this->_apiUrl.$this->_apiVersion.$this->_apiWorkspace.'/'.$actionUrl;
-		return $apiUrl.self::API_VERSION.$this->_getApiWorkspace().'/'.$actionUrl;
-	}
-	
-	
-	private function curlPost($url, $data = null, $authNeeded = true, $customHeader = null, $customRequest = null) 
-	{
-		$this->_helper()->log(__METHOD__);		
-		$this->_helper()->log("CURL URL:");
-		$this->_helper()->log($url);
-		$this->_helper()->log("FINE CURL URL:");
-		
-		$curl = curl_init();
-		$this->_helper()->log($url);
-	
-		curl_setopt($curl, CURLOPT_URL, $url);
-		if ($this->_getApiProxy()) {
-			curl_setopt($curl, CURLOPT_PROXY, $this->_getApiProxy());
-		}
-		$header = array(
-				'X-Forwarded-Ssl:on',
-				'Content-Type:application/json'
-		);
-		if ($authNeeded) {		
-			$header[] = 'Authorization: Bearer ' . $this->_getApiToken();
-		}
-		if (is_array($customHeader)) {
-			$header = array_merge($header, $customHeader);
-		}
-		if ($header) {
-			//$this->_helper()->log(print_r($header, true));			
-			curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
-		}
-		
-		$this->_helper()->log("POST:");
-		$this->_helper()->log(json_decode($data));
-		$this->_helper()->log("FINE POST:");
-				
-		curl_setopt($curl, CURLOPT_POST, TRUE);
-		if (!is_null($data)) {
-			curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
-		}
-		if (!is_null($customRequest)) {
-			curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $customRequest);
-		}
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		$response = curl_exec($curl);
-		//        $this->_helper()->log('HTTP CODE:'.curl_getinfo($curl, CURLINFO_HTTP_CODE));
-	
-				
-		$this->_helper()->log("RESPONSE:");
-		$this->_helper()->log(json_decode($response));
-		$this->_helper()->log("FINE RESPONSE:");
-		
-		
-		
-		if (curl_errno($curl) || $response === false) {
-			$response = curl_error($curl);
-			curl_close($curl);
-			throw new \Exception($response, 667);
-		}
-		
-		$this->_helper()->log("CURL HTTP CODE:");
-		$this->_helper()->log(curl_getinfo($curl, CURLINFO_HTTP_CODE));
-		$this->_helper()->log("FINE CURL HTTP CODE:");
-		
-		$response = json_decode($response);
-		$response->curl_http_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-		$response = json_encode($response);
-		
-		//FIXME La post su session in realtà non torna un vero e proprio errore ma una notice...
-		$tmp = explode('/', $url);		
-		if($tmp[count($tmp)-1] != 'sessions')
-		{
-			
-			if (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 400) {
-				$response = json_decode($response);
-				if (property_exists($response, 'message')) {
-					$message = $response->message;
-				} else {
-					$message = 'Something wrong.';
-				}
-				curl_close($curl);
-				throw new \Exception($message, 668);
-			}
-		}
-		curl_close($curl);
-		//$this->_helper()->log('Curl report: '.print_r(curl_error($curl)));
-		return $response;
-	}
-	
-	
-	private function curlGet($url, $query = null) {
-		$this->_helper()->log(__METHOD__);
-		$curl = curl_init();
-		if ($query) {
-			$url .= '?'.http_build_query($query);
-		}
-		$this->_helper()->log($url);
-		curl_setopt($curl, CURLOPT_URL, $url);
-		if ($this->_getApiProxy()) {
-			curl_setopt($curl, CURLOPT_PROXY, $this->_getApiProxy());
-		}
-		
-		if ($this->_getApiToken()) {
-			curl_setopt($curl, CURLOPT_HTTPHEADER, array(
-					'X-Forwarded-Ssl:on',
-					 'Authorization: Bearer '.$this->_getApiToken(),
-					'Content-Type:application/json'
-			));
-		}
-		curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
-		$response = curl_exec($curl);
-		if ($response === false) {
-			$response = curl_error($curl);
-			curl_close($curl);
-			throw new \Exception($response, 666);
-		}
-		curl_close($curl);
-		return $response;
-	}
+    const API_VERSION = 'hub/v1/workspaces/';
+    
+    protected $_helper = null;
+    
+    protected function _getApiToken()
+    {
+        return $this->_helper()->getConfigData('settings/apitoken', $this->getStoreId());
+    }
+
+    protected function _getApiWorkspace()
+    {
+        return $this->_helper()->getConfigData('settings/apiworkspaceid', $this->getStoreId());
+    }
+    
+    protected function _getNodeId()
+    {
+        $this->_helper()->getConfigData('settings/apinodeid', $this->getStoreId());
+    }
+    
+    protected function _getApiProxy()
+    {
+        return $this->_helper()->getConfigData('settings/useproxy', $this->getStoreId()) ? $this->_helper()->getConfigData('settings/apiproxy', $this->getStoreId()) : false;
+    }
+    
+    public function getRemoteCustomerHub($data)
+    {
+        $this->_helper()->log(__METHOD__);
+        try {
+            $response = $this->curlPost($this->_getApiUrl('customers'), json_encode($data), true);
+            $response = json_decode($response);
+            if ($response->curl_http_code == 409) {
+                unset($data->nodeId);
+                $data->id = $response->data->customer->id;
+                //unset($data->subscriptions);
+                $response = $this->curlPost($response->data->customer->href, json_encode($data), true, null, "PATCH");
+                return json_decode($response);
+            } else {
+                return $response->id;
+            }
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+    
+    public function setRemoteCustomerHubSession($data)
+    {
+        $this->_helper()->log(__METHOD__);
+            $url = $this->_getApiUrl('customers').'/'.$data->id.'/sessions';
+            $session = $data->session;
+            $data = new stdClass();
+            $data->value = $session;
+            $response = $this->curlPost($url, json_encode($data), true);
+            return json_decode($response);
+    }
+    
+        
+    public function deleteCustomerByExternalId($externalId)
+    {
+        $this->_helper()->log(__METHOD__);
+        try {
+            $result = $this->findCustomersByExternalId($externalId);
+            foreach ($result as $customer) {
+                $this->deleteCustomer($customer->id);
+            }
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+    
+    public function deleteCustomer($id)
+    {
+        $this->_helper()->log(__METHOD__);
+        try {
+            $response = $this->curlPost($this->_getApiUrl('customers/'.$id), null, true, null, 'DELETE');
+            return $response;
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+    
+    public function createEvent($data)
+    {
+        $this->_helper()->log(__METHOD__);
+        try {
+            $response = $this->curlPost($this->_getApiUrl('events'), json_encode($data), true);
+            
+            return $response;
+        } catch (\Exception $e) {
+            throw $e;
+        }
+    }
+    
+    public function getAllCustomers($outputAssoc = false)
+    {
+        $result = null;
+        try {
+            $response = $this->curlGet($this->_getApiUrl('customers'), ['nodeId' => $this->_getNodeId(), 'size' => 20]);
+            $response = json_decode($response, true);
+            //return $response;
+            if (!$response) {
+                throw new \Exception('empty response', 664);
+            }
+            if (!isset($response['_embedded']['customers']) || !is_array($response['_embedded']['customers'])) {
+                throw new \Exception('not valid response', 663);
+            }
+            $result = $response['_embedded']['customers'];
+        } catch (\Exception $e) {
+            throw $e;
+        }
+        //if (count($result) > 0) {
+        return $result;
+        //}
+        //return null;
+    }
+     
+    private function _helper()
+    {
+        if ($this->_helper == null) {
+            $this->_helper = Mage::helper('contactlab_hub');
+        }
+        return $this->_helper;
+    }
+    
+    private function _getApiUrl($actionUrl)
+    {
+        $apiUrl = $this->_helper()->getConfigData('settings/apiurl', $this->getStoreId());
+        if (substr($apiUrl, -1) != '/') {
+            $apiUrl .= '/';
+        }
+        
+        //return $this->_apiUrl.$this->_apiVersion.$this->_apiWorkspace.'/'.$actionUrl;
+        return $apiUrl.self::API_VERSION.$this->_getApiWorkspace().'/'.$actionUrl;
+    }
+    
+    private function curlPost($url, $data = null, $authNeeded = true, $customHeader = null, $customRequest = null)
+    {
+        $this->_helper()->log(__METHOD__);
+        $this->_helper()->log("CURL URL:");
+        $this->_helper()->log($url);
+        $this->_helper()->log("FINE CURL URL:");
+        
+        $curl = curl_init();
+        $this->_helper()->log($url);
+    
+        curl_setopt($curl, CURLOPT_URL, $url);
+        if ($this->_getApiProxy()) {
+            curl_setopt($curl, CURLOPT_PROXY, $this->_getApiProxy());
+        }
+        $header = array(
+                'X-Forwarded-Ssl:on',
+                'Content-Type:application/json'
+        );
+        if ($authNeeded) {
+            $header[] = 'Authorization: Bearer ' . $this->_getApiToken();
+        }
+        if (is_array($customHeader)) {
+            $header = array_merge($header, $customHeader);
+        }
+        if ($header) {
+            //$this->_helper()->log(print_r($header, true));
+            curl_setopt($curl, CURLOPT_HTTPHEADER, $header);
+        }
+        
+        $this->_helper()->log("POST:");
+        $this->_helper()->log(json_decode($data));
+        $this->_helper()->log("FINE POST:");
+                
+        curl_setopt($curl, CURLOPT_POST, true);
+        if (!is_null($data)) {
+            curl_setopt($curl, CURLOPT_POSTFIELDS, $data);
+        }
+        if (!is_null($customRequest)) {
+            curl_setopt($curl, CURLOPT_CUSTOMREQUEST, $customRequest);
+        }
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        $response = curl_exec($curl);
+        //        $this->_helper()->log('HTTP CODE:'.curl_getinfo($curl, CURLINFO_HTTP_CODE));
+                
+        $this->_helper()->log("RESPONSE:");
+        $this->_helper()->log(json_decode($response));
+        $this->_helper()->log("FINE RESPONSE:");
+        
+        if (curl_errno($curl) || $response === false) {
+            $response = curl_error($curl);
+            curl_close($curl);
+            throw new \Exception($response, 667);
+        }
+        
+        $this->_helper()->log("CURL HTTP CODE:");
+        $this->_helper()->log(curl_getinfo($curl, CURLINFO_HTTP_CODE));
+        $this->_helper()->log("FINE CURL HTTP CODE:");
+        
+        $response = json_decode($response);
+        $response->curl_http_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        $response = json_encode($response);
+        
+        //FIXME La post su session in realtà non torna un vero e proprio errore ma una notice...
+        $tmp = explode('/', $url);
+        if ($tmp[count($tmp)-1] != 'sessions') {
+            if (curl_getinfo($curl, CURLINFO_HTTP_CODE) == 400) {
+                $response = json_decode($response);
+                if (property_exists($response, 'message')) {
+                    $message = $response->message;
+                } else {
+                    $message = 'Something wrong.';
+                }
+                curl_close($curl);
+                throw new \Exception($message, 668);
+            }
+        }
+        curl_close($curl);
+        //$this->_helper()->log('Curl report: '.print_r(curl_error($curl)));
+        return $response;
+    }
+    
+    private function curlGet($url, $query = null)
+    {
+        $this->_helper()->log(__METHOD__);
+        $curl = curl_init();
+        if ($query) {
+            $url .= '?'.http_build_query($query);
+        }
+        $this->_helper()->log($url);
+        curl_setopt($curl, CURLOPT_URL, $url);
+        if ($this->_getApiProxy()) {
+            curl_setopt($curl, CURLOPT_PROXY, $this->_getApiProxy());
+        }
+        
+        if ($this->_getApiToken()) {
+            curl_setopt($curl, CURLOPT_HTTPHEADER, array(
+                    'X-Forwarded-Ssl:on',
+                     'Authorization: Bearer '.$this->_getApiToken(),
+                    'Content-Type:application/json'
+            ));
+        }
+        curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+        $response = curl_exec($curl);
+        if ($response === false) {
+            $response = curl_error($curl);
+            curl_close($curl);
+            throw new \Exception($response, 666);
+        }
+        curl_close($curl);
+        return $response;
+    }
 }

--- a/app/code/community/Contactlab/Hub/Model/Hub.php
+++ b/app/code/community/Contactlab/Hub/Model/Hub.php
@@ -56,7 +56,6 @@ class Contactlab_Hub_Model_Hub extends Mage_Core_Model_Abstract
             return json_decode($response);
     }
     
-        
     public function deleteCustomerByExternalId($externalId)
     {
         $this->_helper()->log(__METHOD__);
@@ -193,7 +192,7 @@ class Contactlab_Hub_Model_Hub extends Mage_Core_Model_Abstract
         $this->_helper()->log(curl_getinfo($curl, CURLINFO_HTTP_CODE));
         $this->_helper()->log("FINE CURL HTTP CODE:");
         
-        $response = json_decode($response);
+        $response = json_decode($response) ?: new \stdClass(); 
         $response->curl_http_code = curl_getinfo($curl, CURLINFO_HTTP_CODE);
         $response = json_encode($response);
         

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -44,6 +44,9 @@ class Contactlab_Hub_Model_Observer
     
     public function placeHubTracking(Varien_Event_Observer $observer)
     {
+        if (!$this->_helper()->isJsTrackingEnabled()) {
+            return;
+        }
         $controller = $observer->getAction();
         $routeName = $controller->getRequest()->getRouteName();
         $controllerName = $controller->getRequest()->getControllerName();

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -90,8 +90,8 @@ class Contactlab_Hub_Model_Observer
     public function traceCustomerLogin($observer)
     {
         if (isset($_COOKIE['_ch'])) {
-            $cooke = json_decode(Mage::getModel('core/cookie')->get('_ch'));
-            if ($cooke->customerId) {
+            $cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'), true);
+            if ($cookie && $cookie['customerId']) {
                 unset($_COOKIE['_ch']);
                 setcookie('_ch', null, -1, '/');
                 Mage::getModel('core/cookie')->delete('_ch');

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -89,13 +89,10 @@ class Contactlab_Hub_Model_Observer
     
     public function traceCustomerLogin($observer)
     {
-        if (isset($_COOKIE['_ch'])) {
-            $cookie = json_decode(Mage::getModel('core/cookie')->get('_ch'), true);
-            if ($cookie && $cookie['customerId']) {
-                unset($_COOKIE['_ch']);
-                setcookie('_ch', null, -1, '/');
-                Mage::getModel('core/cookie')->delete('_ch');
-            }
+        $cookieModel = Mage::getSingleton('core/cookie');
+        $cookie = json_decode($cookieModel->get('_ch'), true);
+        if ($cookie && $cookie['customerId']) {
+            $cookieModel->set('_ch', '', -1, '/', '');
         }
         
         $event = Mage::getModel('contactlab_hub/event_login');

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -101,6 +101,17 @@ class Contactlab_Hub_Model_Observer
         return $observer;
     }
 
+    public function traceProductCategoryView($observer)
+    {
+        if ($this->_helper()->isJsTrackingEnabled()) {
+            return;
+        }
+        $event = Mage::getModel('contactlab_hub/event_viewedProductCategory');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+
     public function traceCustomerLogin($observer)
     {
         $cookie = json_decode(Mage::getSingleton('core/cookie')->get('_ch'), true);

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -1,271 +1,238 @@
 <?php
-class Contactlab_Hub_Model_Observer 
+class Contactlab_Hub_Model_Observer
 {
     protected $_helper = null;
 
-    private function _helper() 
+    private function _helper()
     {
-        if ($this->_helper == null) 
-        {
+        if ($this->_helper == null) {
             $this->_helper = Mage::helper('contactlab_hub');
         }
         return $this->_helper;
     }
     
-    private function _getConfig($key) 
+    private function _getConfig($key)
     {
         return $this->_helper()->getConfigData($key);
     }
 
-    private function _isEnabled() 
+    private function _isEnabled()
     {
         //return $this->_getConfig('events/enabled')?true:false;
-    	return true;
+        return true;
     }
-	
+    
     public function handleConfigChanges($observer)
-    {    	
-    	$this->_setEnabledFrom($observer);
+    {
+        $this->_setEnabledFrom($observer);
     }
     
     protected function _setEnabledFrom($observer)
     {
-    	$allStores = Mage::app()->getStores();
-		foreach ($allStores as $storeId => $val)
-		{
-    		if(!$this->_getConfig('cron_previous_customers/previous_date'))
-    		{
-    			$this->_helper()->setConfigData('contactlab_hub/cron_previous_customers/previous_date', date('Y-m-d H:i:s'), 'stores', $storeId);
-    		}
-    	}
+        $allStores = Mage::app()->getStores();
+        foreach ($allStores as $storeId => $val) {
+            if (!$this->_getConfig('cron_previous_customers/previous_date')) {
+                $this->_helper()->setConfigData('contactlab_hub/cron_previous_customers/previous_date', date('Y-m-d H:i:s'), 'stores', $storeId);
+            }
+        }
     }
     
+    protected function _getEvent()
+    {
+        return Mage::getModel('contactlab_hub/event');
+    }
     
-	protected function _getEvent() 
-	{
-		return Mage::getModel('contactlab_hub/event');
-	}
-	
-	
-	public function placeHubTracking(Varien_Event_Observer $observer)
-	{
-		
-		$controller = $observer->getAction();
-		$routeName = $controller->getRequest()->getRouteName();
-		$controllerName = $controller->getRequest()->getControllerName();
-		$actionName = $controller->getRequest()->getActionName();
-		$controllerRoute = $routeName.'_'.$controllerName.'_'.$actionName;
-		//echo '<pre>'.$controllerRoute.'</pre>';
-		
-		$hubJs = "\n<!-- ContactHubJs -->\n<script>\nwindow.ch=function(){(ch.q=ch.q||[]).push(arguments)}; ".$this->_helper()->getJsConfigData();						
-		
-		switch ($controllerRoute)
-		{
-	
-			case 'catalog_category_view':
-				$hubJs.= $this->_helper()->getCategoryPageTracking();
-				break;
-					
-			case 'catalog_product_view':
-				$hubJs.= $this->_helper()->getProductPageTracking();
-				break;
-					
-			case 'catalogsearch_result_index':
-				$hubJs.= $this->_helper()->getSearchTracking();
-				break;
-	
-		}
+    public function placeHubTracking(Varien_Event_Observer $observer)
+    {
+        $controller = $observer->getAction();
+        $routeName = $controller->getRequest()->getRouteName();
+        $controllerName = $controller->getRequest()->getControllerName();
+        $actionName = $controller->getRequest()->getActionName();
+        $controllerRoute = $routeName.'_'.$controllerName.'_'.$actionName;
+        //echo '<pre>'.$controllerRoute.'</pre>';
+        
+        $hubJs = "\n<!-- ContactHubJs -->\n<script>\nwindow.ch=function(){(ch.q=ch.q||[]).push(arguments)}; ".$this->_helper()->getJsConfigData();
+        
+        switch ($controllerRoute) {
+            case 'catalog_category_view':
+                $hubJs.= $this->_helper()->getCategoryPageTracking();
+                break;
+                    
+            case 'catalog_product_view':
+                $hubJs.= $this->_helper()->getProductPageTracking();
+                break;
+                    
+            case 'catalogsearch_result_index':
+                $hubJs.= $this->_helper()->getSearchTracking();
+                break;
+        }
 
-		$hubJs.="\n</script>\n<script async src='https://assets.contactlab.it/contacthub/sdk-browser/latest/contacthub.min.js'></script>\n<!-- END ContactHubJs -->";
-		
-		if($hubJs)
-		{
-			$layout = $controller->getLayout();
-			$block = $layout->createBlock('core/text');
-			$block->setText($hubJs);
-			if($layout->getBlock('before_body_end'))
-			{
-				
-				$layout->getBlock('before_body_end')->append($block);
-			}
-		}
-	}
-	
-	public function checkSubscription(Varien_Event_Observer $observer)
-	{
-		/*
+        $hubJs.="\n</script>\n<script async src='https://assets.contactlab.it/contacthub/sdk-browser/latest/contacthub.min.js'></script>\n<!-- END ContactHubJs -->";
+        
+        if ($hubJs) {
+            $layout = $controller->getLayout();
+            $block = $layout->createBlock('core/text');
+            $block->setText($hubJs);
+            if ($layout->getBlock('before_body_end')) {
+                $layout->getBlock('before_body_end')->append($block);
+            }
+        }
+    }
+    
+    public function checkSubscription(Varien_Event_Observer $observer)
+    {
+        /*
 			var_dump('pagina iscrizione newsletter');
 			die();
 			*/
-	}
-	
-	
-    public function traceCustomerLogin($observer) 
-    {    	       
-    	if (isset($_COOKIE['_ch'])) 
-    	{
-    		$cooke = json_decode(Mage::getModel('core/cookie')->get('_ch'));    		
-    		if($cooke->customerId)
-    		{
-    			unset($_COOKIE['_ch']);    		
-    			setcookie('_ch', null, -1, '/');    		
-    			Mage::getModel('core/cookie')->delete('_ch');
-    		}
-    	}    	
-    	
-		$event = Mage::getModel('contactlab_hub/event_login');
-		$event->setEvent($observer->getEvent());
-		$event->trace();		
-		return $observer;
-	}
-	
-	
-	public function traceCustomerLogout($observer)
-	{		
-		$event = Mage::getModel('contactlab_hub/event_logout');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;		
-	}
-	
-	
-	public function traceCustomerRegister($observer) 
-	{
-		/*
+    }
+    
+    public function traceCustomerLogin($observer)
+    {
+        if (isset($_COOKIE['_ch'])) {
+            $cooke = json_decode(Mage::getModel('core/cookie')->get('_ch'));
+            if ($cooke->customerId) {
+                unset($_COOKIE['_ch']);
+                setcookie('_ch', null, -1, '/');
+                Mage::getModel('core/cookie')->delete('_ch');
+            }
+        }
+        
+        $event = Mage::getModel('contactlab_hub/event_login');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCustomerLogout($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_logout');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCustomerRegister($observer)
+    {
+        /*
 		$event = Mage::getModel('contactlab_hub/event_register');
 		$event->setEvent($observer->getEvent());
 		$event->trace();
 		return $observer;
 		*/
-	}
-	
-	
-	public function traceSubscriptionSave($observer) 
-	{	
-		
-		$subscriber = $observer->getEvent()->getSubscriber();	
-		if($subscriber->getSubscriberStatus() == Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED)
-		{
-			if(!$subscriber->getCreatedAt())
-			{
-				$subscriber->setCreatedAt(date('Y-m-d H:i:s'));
-			}
-			$subscriber->setLastSubscribedAt(date('Y-m-d H:i:s'));
-		}
-		elseif($subscriber->getSubscriberStatus() == Mage_Newsletter_Model_Subscriber::STATUS_UNSUBSCRIBED)
-		{
-			$subscriber->setLastSubscribedAt();
-		}
-		
-		$event = Mage::getModel('contactlab_hub/event_subscription');
-		$event->setEvent($observer->getEvent()->setSubscriber($subscriber));
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceChangeStoreEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_changeStore');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-		
-	
-	public function traceCartAddEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_addToCart');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceQuoteRemoveEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_removeToCart');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceCheckoutEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_checkout');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceCompareAddEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_addToCompare');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceCompareRemoveEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_removeToCompare');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceWishlistAddEvent($observer)
-	{
-		$event = Mage::getModel('contactlab_hub/event_addToWishlist');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	
-	public function traceWishlistRemoveEvent($observer)
-	{				
-		$event = Mage::getModel('contactlab_hub/event_removeToWishlist');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	public function traceShipmentEvent($observer)
-	{		
-		$event = Mage::getModel('contactlab_hub/event_shipment');
-		$event->setEvent($observer->getEvent());
-		$event->trace();
-		return $observer;
-	}
-	
-	public function traceCancelOrderEvent($observer)
-	{
-		$order = $observer->getEvent()->getOrder();
-				
-		if (!$order->getId()) {
-			//order not saved in the database
-			return $this;
-		}
-		
-		$OldStatus = $order->getOrigData('status');
-		$NewStatus = $order->getStatus();
-		
-		
-		if (
-			($NewStatus == Mage_Sales_Model_Order::STATE_CANCELED)
-			&& ($OldStatus != $NewStatus)
-		)
-		{
-			$event = Mage::getModel('contactlab_hub/event_cancelOrder');
-			$event->setEvent($observer->getEvent());
-			$event->trace();
-		}
-		return $observer;
-	}
+    }
+    
+    public function traceSubscriptionSave($observer)
+    {
+        $subscriber = $observer->getEvent()->getSubscriber();
+        if ($subscriber->getSubscriberStatus() == Mage_Newsletter_Model_Subscriber::STATUS_SUBSCRIBED) {
+            if (!$subscriber->getCreatedAt()) {
+                $subscriber->setCreatedAt(date('Y-m-d H:i:s'));
+            }
+            $subscriber->setLastSubscribedAt(date('Y-m-d H:i:s'));
+        } elseif ($subscriber->getSubscriberStatus() == Mage_Newsletter_Model_Subscriber::STATUS_UNSUBSCRIBED) {
+            $subscriber->setLastSubscribedAt();
+        }
+        
+        $event = Mage::getModel('contactlab_hub/event_subscription');
+        $event->setEvent($observer->getEvent()->setSubscriber($subscriber));
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceChangeStoreEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_changeStore');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCartAddEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_addToCart');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceQuoteRemoveEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_removeToCart');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCheckoutEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_checkout');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCompareAddEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_addToCompare');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCompareRemoveEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_removeToCompare');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceWishlistAddEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_addToWishlist');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceWishlistRemoveEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_removeToWishlist');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceShipmentEvent($observer)
+    {
+        $event = Mage::getModel('contactlab_hub/event_shipment');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+    
+    public function traceCancelOrderEvent($observer)
+    {
+        $order = $observer->getEvent()->getOrder();
+                
+        if (!$order->getId()) {
+            //order not saved in the database
+            return $this;
+        }
+        
+        $OldStatus = $order->getOrigData('status');
+        $NewStatus = $order->getStatus();
+        
+        
+        if (($NewStatus == Mage_Sales_Model_Order::STATE_CANCELED)
+            && ($OldStatus != $NewStatus)
+        ) {
+            $event = Mage::getModel('contactlab_hub/event_cancelOrder');
+            $event->setEvent($observer->getEvent());
+            $event->trace();
+        }
+
+        return $observer;
+    }
 }
-?>

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -90,12 +90,22 @@ class Contactlab_Hub_Model_Observer
 			*/
     }
     
+    public function traceProductView($observer)
+    {
+        if ($this->_helper()->isJsTrackingEnabled()) {
+            return;
+        }
+        $event = Mage::getModel('contactlab_hub/event_viewedProduct');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+
     public function traceCustomerLogin($observer)
     {
-        $cookieModel = Mage::getSingleton('core/cookie');
-        $cookie = json_decode($cookieModel->get('_ch'), true);
+        $cookie = json_decode(Mage::getSingleton('core/cookie')->get('_ch'), true);
         if ($cookie && $cookie['customerId']) {
-            $cookieModel->set('_ch', '', -1, '/', '');
+            $this->_helper()->deleteTrackingCookie();
         }
         
         $event = Mage::getModel('contactlab_hub/event_login');
@@ -109,6 +119,11 @@ class Contactlab_Hub_Model_Observer
         $event = Mage::getModel('contactlab_hub/event_logout');
         $event->setEvent($observer->getEvent());
         $event->trace();
+
+        // Customer logged out, create a new session id
+        if (!$this->_helper()->isJsTrackingEnabled()) {
+            $this->_helper()->deleteTrackingCookie();
+        }
         return $observer;
     }
     

--- a/app/code/community/Contactlab/Hub/Model/Observer.php
+++ b/app/code/community/Contactlab/Hub/Model/Observer.php
@@ -41,7 +41,7 @@ class Contactlab_Hub_Model_Observer
     {
         return Mage::getModel('contactlab_hub/event');
     }
-    
+
     public function placeHubTracking(Varien_Event_Observer $observer)
     {
         if (!$this->_helper()->isJsTrackingEnabled()) {
@@ -107,6 +107,17 @@ class Contactlab_Hub_Model_Observer
             return;
         }
         $event = Mage::getModel('contactlab_hub/event_viewedProductCategory');
+        $event->setEvent($observer->getEvent());
+        $event->trace();
+        return $observer;
+    }
+
+    public function traceSearch(Varien_Event_Observer $observer)
+    {
+        if ($this->_helper()->isJsTrackingEnabled()) {
+            return;
+        }
+        $event = Mage::getModel('contactlab_hub/event_searched');
         $event->setEvent($observer->getEvent());
         $event->trace();
         return $observer;

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -293,6 +293,9 @@
                 <logfilename>contactlabhub.log</logfilename>
             </settings>
             <js_tracking>
+                <enabled>1</enabled>
+
+                <!-- The disclaimers are actually non editable settings, as Magento does not support simple read-only fields -->
                 <disclaimer_enabled>DISCLAIMER: JS tracking is enabled</disclaimer_enabled>
                 <disclaimer_disabled>DISCLAIMER: JS tracking is disabled</disclaimer_disabled>
             </js_tracking>

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -80,6 +80,15 @@
                     </contactlab_hub>
                 </observers>
             </controller_action_postdispatch_catalog_category_view>
+            <controller_action_postdispatch_catalogsearch_result_index>
+             <observers>
+                    <contactlab_hub>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>traceSearch</method>
+                    </contactlab_hub>
+                </observers>
+            </controller_action_postdispatch_catalogsearch_result_index>
             <customer_logout>
                 <observers>
                     <contactlab_hub>

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -2,7 +2,7 @@
 <config>
     <modules>
         <Contactlab_Hub>
-            <version>1.1.1</version>
+            <version>1.2.0</version>
         </Contactlab_Hub>
     </modules>
     <global>

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -292,6 +292,10 @@
                 <log>0</log>
                 <logfilename>contactlabhub.log</logfilename>
             </settings>
+            <js_tracking>
+                <disclaimer_enabled>DISCLAIMER: JS tracking is enabled</disclaimer_enabled>
+                <disclaimer_disabled>DISCLAIMER: JS tracking is disabled</disclaimer_disabled>
+            </js_tracking>
             <events>              
 				<evtregister>1</evtregister>
                 <loggedIn>1</loggedIn>

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -71,6 +71,15 @@
                     </contactlab_hub>
                 </observers>
             </controller_action_postdispatch_catalog_product_view>
+            <controller_action_postdispatch_catalog_category_view>
+             <observers>
+                    <contactlab_hub>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>traceProductCategoryView</method>
+                    </contactlab_hub>
+                </observers>
+            </controller_action_postdispatch_catalog_category_view>
             <customer_logout>
                 <observers>
                     <contactlab_hub>

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -6,24 +6,24 @@
         </Contactlab_Hub>
     </modules>
     <global>
-    	<models>
+        <models>
             <contactlab_hub>
                 <class>Contactlab_Hub_Model</class>
                 <resourceModel>contactlab_hub_resource</resourceModel>
             </contactlab_hub>
             <contactlab_hub_resource>
-            	<class>Contactlab_Hub_Model_Resource</class>
+                <class>Contactlab_Hub_Model_Resource</class>
                 <deprecatedNode>contactlab_hub_mysql4</deprecatedNode>
                 <entities>
                     <event>
                         <table>contactlab_hub_event</table>
                     </event>
                     <previouscustomers>
-                    	<table>contactlab_hub_previouscustomers</table>
-                    </previouscustomers> 
+                        <table>contactlab_hub_previouscustomers</table>
+                    </previouscustomers>
                     <abandoned_carts>
-                    	<table>contactlab_hub_abandoned_carts</table>
-                    </abandoned_carts>                    
+                        <table>contactlab_hub_abandoned_carts</table>
+                    </abandoned_carts>
                 </entities>
             </contactlab_hub_resource>
             <contactlab_hub_eventhub>
@@ -39,19 +39,19 @@
                     <module>Contactlab_Hub</module>
                     <class>Mage_Customer_Model_Entity_Setup</class>
                 </setup>
-  			</contactlab_hub_setup>
+            </contactlab_hub_setup>
         </resources>
-	    <helpers>
-	    	<contactlab_hub>
-	    		<class>Contactlab_Hub_Helper</class>
-	    	</contactlab_hub>
-	    </helpers>
+        <helpers>
+            <contactlab_hub>
+                <class>Contactlab_Hub_Helper</class>
+            </contactlab_hub>
+        </helpers>
         <blocks>
             <contactlab_hub>
                 <class>Contactlab_Hub_Block</class>
             </contactlab_hub>
-        </blocks> 	
-     	<events>
+        </blocks>
+        <events>
             <!-- CUSTOMER EVENTS -->
             <customer_login>
                 <observers>
@@ -63,7 +63,7 @@
                 </observers>
             </customer_login>
             <controller_action_postdispatch_catalog_product_view>
-             <observers>
+                <observers>
                     <contactlab_hub>
                         <type>singleton</type>
                         <class>contactlab_hub/observer</class>
@@ -72,7 +72,7 @@
                 </observers>
             </controller_action_postdispatch_catalog_product_view>
             <controller_action_postdispatch_catalog_category_view>
-             <observers>
+                <observers>
                     <contactlab_hub>
                         <type>singleton</type>
                         <class>contactlab_hub/observer</class>
@@ -81,7 +81,7 @@
                 </observers>
             </controller_action_postdispatch_catalog_category_view>
             <controller_action_postdispatch_catalogsearch_result_index>
-             <observers>
+                <observers>
                     <contactlab_hub>
                         <type>singleton</type>
                         <class>contactlab_hub/observer</class>
@@ -115,31 +115,31 @@
                         <method>traceSubscriptionSave</method>
                     </contactlab_hub>
                 </observers>
-            </newsletter_subscriber_save_before>            		
-			<controller_action_predispatch_newsletter_manage_index>
-				<observers>
-	                <contactlab_hub_check_subscription>
-	                    <type>singleton</type>
-	                    <class>contactlab_hub/observer</class>
-	                    <method>checkSubscription</method>
-	                </contactlab_hub_check_subscription>
-	            </observers>
-			</controller_action_predispatch_newsletter_manage_index>
+            </newsletter_subscriber_save_before>
+            <controller_action_predispatch_newsletter_manage_index>
+                <observers>
+                    <contactlab_hub_check_subscription>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>checkSubscription</method>
+                    </contactlab_hub_check_subscription>
+                </observers>
+            </controller_action_predispatch_newsletter_manage_index>
             <!-- PRODUCT EVENTS -->
-			<catalog_product_compare_add_product>
-            	<observers>
+            <catalog_product_compare_add_product>
+                <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceCompareAddEvent</method>
                     </contactlab_hub>
                 </observers>
             </catalog_product_compare_add_product>
             <catalog_product_compare_remove_product>
-            	<observers>
+                <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceCompareRemoveEvent</method>
                     </contactlab_hub>
                 </observers>
@@ -156,22 +156,22 @@
             <wishlist_add_product>
                 <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceWishlistAddEvent</method>
                     </contactlab_hub>
                 </observers>
             </wishlist_add_product>
-			<wishlist_item_delete_before>
-            	<observers>
+            <wishlist_item_delete_before>
+                <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceWishlistRemoveEvent</method>
                     </contactlab_hub>
                 </observers>
             </wishlist_item_delete_before>
-			<!-- SLASES EVENTS -->
+            <!-- SLASES EVENTS -->
             <sales_order_place_after>
                 <observers>
                     <contactlab_hub>
@@ -181,9 +181,8 @@
                     </contactlab_hub>
                 </observers>
             </sales_order_place_after>
-           
             <checkout_type_onepage_save_order_after>
-				<observers>
+                <observers>
                     <contactlab_hub>
                         <type>singleton</type>
                         <class>contactlab_hub/observer</class>
@@ -191,69 +190,64 @@
                     </contactlab_hub>
                 </observers>
             </checkout_type_onepage_save_order_after>
-            
             <checkout_cart_product_add_after>
                 <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceCartAddEvent</method>
                     </contactlab_hub>
                 </observers>
             </checkout_cart_product_add_after>
-            
             <sales_quote_remove_item>
-            	<observers>
+                <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceQuoteRemoveEvent</method>
                     </contactlab_hub>
                 </observers>
             </sales_quote_remove_item>
-            
             <sales_order_save_after>
-               <observers>
+                <observers>
                     <contactlab_hub>
-                    	<type>singleton</type>
-						<class>contactlab_hub/observer</class>
-						<method>traceCancelOrderEvent</method>
-					</contactlab_hub>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>traceCancelOrderEvent</method>
+                    </contactlab_hub>
                 </observers>
-            </sales_order_save_after> 
-            
+            </sales_order_save_after>
             <sales_order_shipment_save_after>
-            	<observers>
+                <observers>
                     <contactlab_hub>
-     					<type>singleton</type>
-     					<class>contactlab_hub/observer</class>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
                         <method>traceShipmentEvent</method>
                     </contactlab_hub>
                 </observers>
             </sales_order_shipment_save_after>
-     	</events>     
+        </events>
     </global>
-    
-    <frontend>    	
-    	<events>    	
-	        <controller_action_predispatch>
-	            <observers>
-	                <contactlab_hub>
-	                    <type>singleton</type>
-	                    <class>contactlab_hub/observer</class>
-	                    <method>traceChangeStoreEvent</method>
-	                </contactlab_hub>
-	            </observers>
-	        </controller_action_predispatch>
-	        <controller_action_layout_generate_blocks_after>
-	            <observers>
-	                <contactlab_hub_place_tracking>
-	                    <type>singleton</type>
-	                    <class>contactlab_hub/observer</class>
-	                    <method>placeHubTracking</method>
-	                </contactlab_hub_place_tracking>
-	            </observers>
-	        </controller_action_layout_generate_blocks_after>	       
+    <frontend>
+        <events>
+            <controller_action_predispatch>
+                <observers>
+                    <contactlab_hub>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>traceChangeStoreEvent</method>
+                    </contactlab_hub>
+                </observers>
+            </controller_action_predispatch>
+            <controller_action_layout_generate_blocks_after>
+                <observers>
+                    <contactlab_hub_place_tracking>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>placeHubTracking</method>
+                    </contactlab_hub_place_tracking>
+                </observers>
+            </controller_action_layout_generate_blocks_after>
         </events>
         <layout>
             <updates>
@@ -262,8 +256,8 @@
                 </contactlab_layout>
             </updates>
         </layout>
-	</frontend>
-	<admin>
+    </frontend>
+    <admin>
         <routers>
             <adminhtml>
                 <args>
@@ -274,8 +268,8 @@
             </adminhtml>
         </routers>
     </admin>
-	<adminhtml>
-		<layout>
+    <adminhtml>
+        <layout>
             <updates>
                 <contactlab_subscribers>
                     <file>contactlab/hub.xml</file>
@@ -291,18 +285,18 @@
                 </contactlab_subscribers>
             </modules>
         </translate>
-		<events>			
-			<admin_system_config_changed_section_contactlab_hub>
-			    <observers>
-			        <contactlab_hub>
-			            <type>singleton</type>
-			            <class>contactlab_hub/observer</class>
-	                    <method>handleConfigChanges</method>
-			        </contactlab_hub>
-			    </observers>
-			</admin_system_config_changed_section_contactlab_hub>			
-		</events>
-	</adminhtml>
+        <events>
+            <admin_system_config_changed_section_contactlab_hub>
+                <observers>
+                    <contactlab_hub>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>handleConfigChanges</method>
+                    </contactlab_hub>
+                </observers>
+            </admin_system_config_changed_section_contactlab_hub>
+        </events>
+    </adminhtml>
     <default>
         <contactlab_hub>
             <settings>
@@ -321,96 +315,87 @@
             </settings>
             <js_tracking>
                 <enabled>1</enabled>
-
                 <!-- The disclaimers are actually non editable settings, as Magento does not support simple read-only fields -->
                 <disclaimer_enabled>DISCLAIMER: JS tracking is enabled</disclaimer_enabled>
                 <disclaimer_disabled>DISCLAIMER: JS tracking is disabled</disclaimer_disabled>
             </js_tracking>
-            <events>              
-				<evtregister>1</evtregister>
+            <events>
+                <evtregister>1</evtregister>
                 <loggedIn>1</loggedIn>
                 <loggedOut>1</loggedOut>
                 <campaignName>Magento_Campaign</campaignName>
-               	<campaignSubscribed>1</campaignSubscribed>
+                <campaignSubscribed>1</campaignSubscribed>
                 <campaignUnsubscribed>1</campaignUnsubscribed>
                 <changedSetting>1</changedSetting>
-               	<completedOrder>1</completedOrder>
+                <completedOrder>1</completedOrder>
                 <searched>1</searched>
                 <addedProduct>1</addedProduct>
                 <removedProduct>1</removedProduct>
-                <abandonedCart>1</abandonedCart >
+                <abandonedCart>1</abandonedCart>
                 <send_to_not_subscribed>0</send_to_not_subscribed>
                 <min_minutes_from_last_update>120</min_minutes_from_last_update>
-                <max_minutes_from_last_update>1440</max_minutes_from_last_update>                           
+                <max_minutes_from_last_update>1440</max_minutes_from_last_update>
                 <addedWishlist>1</addedWishlist>
                 <removedWishlist>1</removedWishlist>
                 <addedCompare>1</addedCompare>
                 <removedCompare>1</removedCompare>
                 <viewedProduct>1</viewedProduct>
                 <viewedProductCategory>1</viewedProductCategory>
-                <orderShipped>1</orderShipped> 
+                <orderShipped>1</orderShipped>
                 <base_currency>EUR</base_currency>
-	            <website_currency>EUR</website_currency>
-	            <exchange_rate>1</exchange_rate>	                        
-            </events>      
+                <website_currency>EUR</website_currency>
+                <exchange_rate>1</exchange_rate>
+            </events>
             <cron_events>
-            	<limit>30</limit>
-            	<frequency>I</frequency>
-            	<repeat_minutes>1</repeat_minutes>
+                <limit>30</limit>
+                <frequency>I</frequency>
+                <repeat_minutes>1</repeat_minutes>
             </cron_events>
             <cron_previous_customers>
-            	<limit>50</limit>
-            	<frequency>I</frequency>
-            	<repeat_minutes>5</repeat_minutes>
+                <limit>50</limit>
+                <frequency>I</frequency>
+                <repeat_minutes>5</repeat_minutes>
             </cron_previous_customers>
         </contactlab_hub>
     </default>
-
     <crontab>
         <jobs>
-        	<contactlab_hub_export_events>
+            <contactlab_hub_export_events>
                 <description>Export Events To Hub</description>
                 <!-- Consume the queue every minute 
-                <schedule>                    
-                    <cron_expr>* * * * *</cron_expr>
-                </schedule>
+                <schedule><cron_expr>* * * * *</cron_expr></schedule>
                 -->
                 <run>
                     <model>contactlab_hub/cron::exportEvents</model>
                 </run>
             </contactlab_hub_export_events>
-       		<contactlab_hub_export_previous_customers>
+            <contactlab_hub_export_previous_customers>
                 <description>Export Previous Customers</description>
                 <!--
-                <schedule>                    
-                    <cron_expr>* * * * *</cron_expr>
-                </schedule>
+                <schedule><cron_expr>* * * * *</cron_expr></schedule>
                 -->
                 <run>
                     <model>contactlab_hub/cron::exportPreviousCustomers</model>
                 </run>
             </contactlab_hub_export_previous_customers>
             <contactlab_hub_abandoned_carts>
-                <description>Export Events To Hub</description>                
-                <schedule>                    
+                <description>Export Events To Hub</description>
+                <schedule>
                     <cron_expr>* * * * *</cron_expr>
-                </schedule>                
+                </schedule>
                 <run>
                     <model>contactlab_hub/cron::getAbandonedCarts</model>
                 </run>
             </contactlab_hub_abandoned_carts>
-            
             <contactlab_hub_import_subscribers>
                 <description>Import Subscribers</description>
                 <!--
-                <schedule>                    
-                    <cron_expr>* * * * *</cron_expr>
-                </schedule>
+                <schedule><cron_expr>* * * * *</cron_expr></schedule>
                 -->
                 <run>
                     <model>contactlab_hub/cron::importSubscribers</model>
                 </run>
-            </contactlab_hub_import_subscribers>                       
+            </contactlab_hub_import_subscribers>
         </jobs>
     </crontab>
 </config>

--- a/app/code/community/Contactlab/Hub/etc/config.xml
+++ b/app/code/community/Contactlab/Hub/etc/config.xml
@@ -62,6 +62,15 @@
                     </contactlab_hub>
                 </observers>
             </customer_login>
+            <controller_action_postdispatch_catalog_product_view>
+             <observers>
+                    <contactlab_hub>
+                        <type>singleton</type>
+                        <class>contactlab_hub/observer</class>
+                        <method>traceProductView</method>
+                    </contactlab_hub>
+                </observers>
+            </controller_action_postdispatch_catalog_product_view>
             <customer_logout>
                 <observers>
                     <contactlab_hub>

--- a/app/code/community/Contactlab/Hub/etc/system.xml
+++ b/app/code/community/Contactlab/Hub/etc/system.xml
@@ -1,490 +1,488 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-    <sections>
-        <contactlab_hub translate="label" module="contactlab_hub">
-            <label>Contacthub</label>
-            <tab>contactlab</tab>
-            <sort_order>1001</sort_order>
-            <show_in_default>1</show_in_default>
-            <show_in_website>1</show_in_website>
-            <show_in_store>1</show_in_store>
-            <groups>
-            	<settings translate="label" module="contactlab_hub">
-                    <label>General</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>10</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
- 
-                    <fields>
-                        <heading_apisetting translate="label">
-                            <label>API Settings</label>
-                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-                            <sort_order>15</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </heading_apisetting>
-                        <apitoken translate="label">
-                            <label>ApiToken: </label>
-                            <comment>Contacthub Api token</comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>20</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </apitoken>
-                        <apiurl>
-                            <label>Api base url: </label>
-                            <comment></comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>40</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </apiurl>
-                        <apiworkspaceid>
-                            <label>Api Workspace ID: </label>
-                            <comment></comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>41</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </apiworkspaceid>
-                        <apinodeid>
-                            <label>Api Node ID: </label>
-                            <comment></comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>42</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </apinodeid>
-                        <useproxy>
-                            <label>Use Proxy: </label>
-                            <comment></comment>
-                            <frontend_type>select</frontend_type>
-                            <sort_order>45</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                        </useproxy>
-                        <apiproxy>
-                            <label>Proxy: </label>
-                            <comment>Format URL:PORT</comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>47</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <depends>
-                                <useproxy>1</useproxy>
-                            </depends>
-                        </apiproxy>
-                        <heading_behavior translate="label">
-                            <label>Behavior</label>
-                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-                            <sort_order>50</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </heading_behavior>
-                        <send_anonymous translate="label">
-                            <label>Send anonymous event: </label>
-                            <comment></comment>
-                            <frontend_type>radios</frontend_type>
-                            <sort_order>51</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                        </send_anonymous>
-                        <heading_debug translate="label">
-                            <label>Debug settings</label>
-                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-                            <sort_order>109</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </heading_debug>
-                        <log translate="label">
-                            <label>Log: </label>
-                            <comment></comment>
-                            <frontend_type>select</frontend_type>
-                            <sort_order>110</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-                        </log>
-                        <logfilename>
-                            <label>File name: </label>
-                            <comment></comment>
-                            <frontend_type>text</frontend_type>
-                            <sort_order>115</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <depends>
-                                <log>2</log>
-                            </depends>
-                        </logfilename>                        
-                    </fields>
-                </settings>
-            <js_tracking translate="label" module="contactlab_hub">
-                    <label>Javascript tracking</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>20</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>                                     
-                        <enabled translate="label">
-                            <label>Enable JS tracking</label>
-                    		 <frontend_type>select</frontend_type>
-	                    	 <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>0</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </enabled>
-
+	<sections>
+		<contactlab_hub translate="label" module="contactlab_hub">
+			<label>Contacthub</label>
+			<tab>contactlab</tab>
+			<sort_order>1001</sort_order>
+			<show_in_default>1</show_in_default>
+			<show_in_website>1</show_in_website>
+			<show_in_store>1</show_in_store>
+			<groups>
+				<settings translate="label" module="contactlab_hub">
+					<label>General</label>
+					<frontend_type>text</frontend_type>
+					<sort_order>10</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>1</show_in_website>
+					<show_in_store>1</show_in_store>
+					<fields>
+						<heading_apisetting translate="label">
+							<label>API Settings</label>
+							<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+							<sort_order>15</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</heading_apisetting>
+						<apitoken translate="label">
+							<label>ApiToken: </label>
+							<comment>Contacthub Api token</comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>20</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</apitoken>
+						<apiurl>
+							<label>Api base url: </label>
+							<comment></comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>40</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</apiurl>
+						<apiworkspaceid>
+							<label>Api Workspace ID: </label>
+							<comment></comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>41</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</apiworkspaceid>
+						<apinodeid>
+							<label>Api Node ID: </label>
+							<comment></comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>42</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</apinodeid>
+						<useproxy>
+							<label>Use Proxy: </label>
+							<comment></comment>
+							<frontend_type>select</frontend_type>
+							<sort_order>45</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+						</useproxy>
+						<apiproxy>
+							<label>Proxy: </label>
+							<comment>Format URL:PORT</comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>47</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends>
+								<useproxy>1</useproxy>
+							</depends>
+						</apiproxy>
+						<heading_behavior translate="label">
+							<label>Behavior</label>
+							<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+							<sort_order>50</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</heading_behavior>
+						<send_anonymous translate="label">
+							<label>Send anonymous event: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>51</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+						</send_anonymous>
+						<heading_debug translate="label">
+							<label>Debug settings</label>
+							<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+							<sort_order>109</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</heading_debug>
+						<log translate="label">
+							<label>Log: </label>
+							<comment></comment>
+							<frontend_type>select</frontend_type>
+							<sort_order>110</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</log>
+						<logfilename>
+							<label>File name: </label>
+							<comment></comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>115</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends>
+								<log>2</log>
+							</depends>
+						</logfilename>
+					</fields>
+				</settings>
+				<js_tracking translate="label" module="contactlab_hub">
+					<label>Javascript tracking</label>
+					<frontend_type>text</frontend_type>
+					<sort_order>20</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>1</show_in_website>
+					<show_in_store>1</show_in_store>
+					<fields>
+						<enabled translate="label">
+							<label>Enable JS tracking</label>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+							<sort_order>0</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</enabled>
 						<untrusted_token translate="label comment">
 							<label>Untrusted token</label>
 							<comment>API token for Javascript</comment>
 							<frontend_type>text</frontend_type>
-	                        <sort_order>0</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-							<depends><enabled>1</enabled></depends>
+							<sort_order>0</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends>
+								<enabled>1</enabled>
+							</depends>
 						</untrusted_token>
-
 						<disclaimer_enabled>
 							<frontend_model>contactlab_hub/adminhtml_system_config_field_readonly</frontend_model>
-	                        <sort_order>0</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-							<depends><enabled>1</enabled></depends>
+							<sort_order>0</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends>
+								<enabled>1</enabled>
+							</depends>
 						</disclaimer_enabled>
-
 						<disclaimer_disabled>
 							<frontend_model>contactlab_hub/adminhtml_system_config_field_readonly</frontend_model>
-	                        <sort_order>0</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-							<depends><enabled>0</enabled></depends>
+							<sort_order>0</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<depends>
+								<enabled>0</enabled>
+							</depends>
 						</disclaimer_disabled>
 					</fields>
 				</js_tracking>
-                <events translate="label" module="contactlab_hub">
-                    <label>Event Settings</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>20</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>1</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>                                     
-                        <heading_events translate="label">
-                            <label>General Events</label>
-                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-                            <sort_order>0</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </heading_events>
-                        
-	                        <!--  NON C'è EVENTO?-->  				
-							<evtregister translate="label">
-	                            <label>Registered: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>1</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </evtregister>
-	                        <loggedIn translate="label">
-	                            <label>LoggedIn: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>2</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </loggedIn>
-	                        <loggedOut translate="label">
-	                            <label>LoggedOut: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>3</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </loggedOut>
-	                        <changedSetting translate="label">
-	                            <label>Locale changed: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>4</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </changedSetting>
-	                        <viewedProductCategory>
-	                        	<label>Category viewed: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>5</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </viewedProductCategory>
-	                        <viewedProduct translate="label">
-	                            <label>Product viewed: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>6</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </viewedProduct>
-	                        <addedWishlist translate="label">
-	                            <label>Product added to wishlist: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>7</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </addedWishlist>
-	                        <removedWishlist translate="label">
-	                            <label>Product removed from wishlist: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>8</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </removedWishlist>
-	                        <addedCompare translate="label">
-	                            <label>Product added to compare: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>9</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </addedCompare>
-	                        <removedCompare translate="label">
-	                            <label>Product removed from compare: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>10</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </removedCompare>
-                        	<searched translate="label">
-	                            <label>Search: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>11</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </searched>
-                        
-                        <subscriber_events translate="label">
-                            <label>Subscriber Events</label>
-                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-                            <sort_order>100</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </subscriber_events>
-                        	
-                        	<campaignName translate="label">
-	                            <label>Newsletter Campaign: </label>
-	                            <comment>Campaign Name e.g. (Magento_Campaign)</comment>
-	                            <frontend_type>text</frontend_type>
-	                            <sort_order>101</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>                            
-	                        </campaignName>
-	                       <campaignSubscribed translate="label">
-	                            <label>Newsletter subscribed: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>102</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </campaignSubscribed>
-	                        <campaignUnsubscribed translate="label">
-	                            <label>Newsletter unsubscribed: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>103</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </campaignUnsubscribed>
-	                        
-                        <sales_events translate="label">
-                            <label>Sales Events</label>
-                            <frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
-                            <sort_order>200</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>1</show_in_store>
-                        </sales_events>                        	
-                        	<addedProduct translate="label">
-	                            <label>Product added to cart: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>201</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </addedProduct>
-	                        <removedProduct translate="label">
-	                            <label>Product removed from cart: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>202</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </removedProduct>
-                        	<completedOrder translate="label">
-	                            <label>Checkout: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>203</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </completedOrder>
-                        	<abandonedCart translate="label">
-	                            <label>Abandoned Cart: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>204</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </abandonedCart >
-	                        <send_to_not_subscribed translate="label">
-	                            <label>Send Abandoned Cart event from non-subscribed customers</label>
-	                            <frontend_type>select</frontend_type>
-	                            <source_model>adminhtml/system_config_source_yesno</source_model>
-	                            <sort_order>205</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>                            
-	                        </send_to_not_subscribed>
-	                        <min_minutes_from_last_update translate="label">
-	                            <label>Minimum number of minutes before sending an Abandoned Cart event</label>
-	                            <frontend_type>text</frontend_type>
-	                            <sort_order>206</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <validate>validate-not-negative-number validate-digits validate-is-min-of-range</validate>                            
-	                        </min_minutes_from_last_update>
-	                        <max_minutes_from_last_update translate="label">
-	                            <label>Maximum number of minutes before sending an Abandoned Cart event</label>
-	                            <frontend_type>text</frontend_type>
-	                            <sort_order>207</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <validate>validate-not-negative-number validate-digits validate-is-max-of-range</validate>                            
-	                        </max_minutes_from_last_update>
-	                        <orderShipped>
-	                        	<label>Order Shipped: </label>
-	                            <comment></comment>
-	                            <frontend_type>radios</frontend_type>
-	                            <sort_order>208</sort_order>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>1</show_in_store>
-	                            <source_model>adminhtml/system_config_source_enabledisable</source_model>
-	                        </orderShipped>
-	                        
-	                        <base_currency translate="label comment">
-	                            <label>Base Currency</label>
-	                            <frontend_type>select</frontend_type>
-	                            <frontend_model>directory/adminhtml_frontend_currency_base</frontend_model>
-	                            <source_model>adminhtml/system_config_source_currency</source_model>	                            
-	                            <sort_order>209</sort_order>
-	                            <comment><![CDATA[Base currency is used for all online payment transactions. Scope is defined by the catalog price scope ("Catalog" > "Price" > "Catalog Price Scope").]]></comment>
-	                            <show_in_default>1</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>0</show_in_store>
-	                        </base_currency>
-	                        <website_currency translate="label">
-	                            <label>Website Currency</label>
-	                            <frontend_type>select</frontend_type>
-	                            <source_model>adminhtml/system_config_source_currency</source_model>
-	                            <sort_order>210</sort_order>
-	                            <show_in_default>0</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>0</show_in_store>
-	                        </website_currency>
-	                        <exchange_rate translate="label">
-	                            <label>Exchange Rate</label>
-	                            <frontend_type>text</frontend_type>
-	                            <sort_order>211</sort_order>
-	                            <show_in_default>0</show_in_default>
-	                            <show_in_website>1</show_in_website>
-	                            <show_in_store>0</show_in_store>
-	                            <validate>validate-not-negative-number</validate>                            
-	                        </exchange_rate>	                       
-                    </fields>
-                </events>    
-                
-                <extra_properties translate="label">
-                    <label>Extra Properties</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>30</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>0</show_in_website>
-                    <show_in_store>0</show_in_store>
-                    <fields> 
-                    	<hub_fixed_1>
-                    		 <label>Hub Attribute 1</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>10</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_fixed_1>
-                    	<magento_fixed_1>
+				<events translate="label" module="contactlab_hub">
+					<label>Event Settings</label>
+					<frontend_type>text</frontend_type>
+					<sort_order>20</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>1</show_in_website>
+					<show_in_store>1</show_in_store>
+					<fields>
+						<heading_events translate="label">
+							<label>General Events</label>
+							<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+							<sort_order>0</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</heading_events>
+						<!--  NON C'è EVENTO?-->
+						<evtregister translate="label">
+							<label>Registered: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>1</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</evtregister>
+						<loggedIn translate="label">
+							<label>LoggedIn: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>2</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</loggedIn>
+						<loggedOut translate="label">
+							<label>LoggedOut: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>3</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</loggedOut>
+						<changedSetting translate="label">
+							<label>Locale changed: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>4</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</changedSetting>
+						<viewedProductCategory>
+							<label>Category viewed: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>5</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</viewedProductCategory>
+						<viewedProduct translate="label">
+							<label>Product viewed: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>6</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</viewedProduct>
+						<addedWishlist translate="label">
+							<label>Product added to wishlist: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>7</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</addedWishlist>
+						<removedWishlist translate="label">
+							<label>Product removed from wishlist: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>8</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</removedWishlist>
+						<addedCompare translate="label">
+							<label>Product added to compare: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>9</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</addedCompare>
+						<removedCompare translate="label">
+							<label>Product removed from compare: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>10</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</removedCompare>
+						<searched translate="label">
+							<label>Search: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>11</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</searched>
+						<subscriber_events translate="label">
+							<label>Subscriber Events</label>
+							<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+							<sort_order>100</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</subscriber_events>
+						<campaignName translate="label">
+							<label>Newsletter Campaign: </label>
+							<comment>Campaign Name e.g. (Magento_Campaign)</comment>
+							<frontend_type>text</frontend_type>
+							<sort_order>101</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</campaignName>
+						<campaignSubscribed translate="label">
+							<label>Newsletter subscribed: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>102</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</campaignSubscribed>
+						<campaignUnsubscribed translate="label">
+							<label>Newsletter unsubscribed: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>103</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</campaignUnsubscribed>
+						<sales_events translate="label">
+							<label>Sales Events</label>
+							<frontend_model>adminhtml/system_config_form_field_heading</frontend_model>
+							<sort_order>200</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</sales_events>
+						<addedProduct translate="label">
+							<label>Product added to cart: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>201</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</addedProduct>
+						<removedProduct translate="label">
+							<label>Product removed from cart: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>202</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</removedProduct>
+						<completedOrder translate="label">
+							<label>Checkout: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>203</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</completedOrder>
+						<abandonedCart translate="label">
+							<label>Abandoned Cart: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>204</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</abandonedCart>
+						<send_to_not_subscribed translate="label">
+							<label>Send Abandoned Cart event from non-subscribed customers</label>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+							<sort_order>205</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</send_to_not_subscribed>
+						<min_minutes_from_last_update translate="label">
+							<label>Minimum number of minutes before sending an Abandoned Cart event</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>206</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<validate>validate-not-negative-number validate-digits validate-is-min-of-range</validate>
+						</min_minutes_from_last_update>
+						<max_minutes_from_last_update translate="label">
+							<label>Maximum number of minutes before sending an Abandoned Cart event</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>207</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<validate>validate-not-negative-number validate-digits validate-is-max-of-range</validate>
+						</max_minutes_from_last_update>
+						<orderShipped>
+							<label>Order Shipped: </label>
+							<comment></comment>
+							<frontend_type>radios</frontend_type>
+							<sort_order>208</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+							<source_model>adminhtml/system_config_source_enabledisable</source_model>
+						</orderShipped>
+						<base_currency translate="label comment">
+							<label>Base Currency</label>
+							<frontend_type>select</frontend_type>
+							<frontend_model>directory/adminhtml_frontend_currency_base</frontend_model>
+							<source_model>adminhtml/system_config_source_currency</source_model>
+							<sort_order>209</sort_order>
+							<comment>
+								<![CDATA[Base currency is used for all online payment transactions. Scope is defined by the catalog price scope ("Catalog"> "Price"> "Catalog Price Scope").]]>
+							</comment>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>0</show_in_store>
+						</base_currency>
+						<website_currency translate="label">
+							<label>Website Currency</label>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_currency</source_model>
+							<sort_order>210</sort_order>
+							<show_in_default>0</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>0</show_in_store>
+						</website_currency>
+						<exchange_rate translate="label">
+							<label>Exchange Rate</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>211</sort_order>
+							<show_in_default>0</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>0</show_in_store>
+							<validate>validate-not-negative-number</validate>
+						</exchange_rate>
+					</fields>
+				</events>
+				<extra_properties translate="label">
+					<label>Extra Properties</label>
+					<frontend_type>text</frontend_type>
+					<sort_order>30</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>0</show_in_website>
+					<show_in_store>0</show_in_store>
+					<fields>
+						<hub_fixed_1>
+							<label>Hub Attribute 1</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>10</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_fixed_1>
+						<magento_fixed_1>
 							<label>Magento Attribute 1</label>
 							<frontend_type>select</frontend_type>
 							<source_model>contactlab_hub/adminhtml_system_config_source_extraProperties</source_model>
@@ -492,16 +490,16 @@
 							<show_in_default>1</show_in_default>
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
-	                   	</magento_fixed_1>  
-	                   	<hub_fixed_2>
-                    		 <label>Hub Attribute 2</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>20</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_fixed_2>
-                    	<magento_fixed_2>
+						</magento_fixed_1>
+						<hub_fixed_2>
+							<label>Hub Attribute 2</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>20</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_fixed_2>
+						<magento_fixed_2>
 							<label>Magento Attribute 2</label>
 							<frontend_type>select</frontend_type>
 							<source_model>contactlab_hub/adminhtml_system_config_source_extraProperties</source_model>
@@ -509,16 +507,16 @@
 							<show_in_default>1</show_in_default>
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
-	                   	</magento_fixed_2>
-	                   	<hub_fixed_3>
-                    		 <label>Hub Attribute 3</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>30</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_fixed_3>
-                    	<magento_fixed_3>
+						</magento_fixed_2>
+						<hub_fixed_3>
+							<label>Hub Attribute 3</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>30</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_fixed_3>
+						<magento_fixed_3>
 							<label>Magento Attribute 3</label>
 							<frontend_type>select</frontend_type>
 							<source_model>contactlab_hub/adminhtml_system_config_source_extraProperties</source_model>
@@ -526,16 +524,16 @@
 							<show_in_default>1</show_in_default>
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
-	                   	</magento_fixed_3>	                   	
-	                   	<hub_fixed_4>
-                    		 <label>Hub Attribute 4</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>40</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_fixed_4>
-                    	<magento_fixed_4>
+						</magento_fixed_3>
+						<hub_fixed_4>
+							<label>Hub Attribute 4</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>40</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_fixed_4>
+						<magento_fixed_4>
 							<label>Magento Attribute 4</label>
 							<frontend_type>select</frontend_type>
 							<source_model>contactlab_hub/adminhtml_system_config_source_extraProperties</source_model>
@@ -543,16 +541,16 @@
 							<show_in_default>1</show_in_default>
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
-	                   	</magento_fixed_4>	                   	
-	                   	<hub_fixed_5>
-                    		 <label>Hub Attribute 5</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>50</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_fixed_5>
-                    	<magento_fixed_5>
+						</magento_fixed_4>
+						<hub_fixed_5>
+							<label>Hub Attribute 5</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>50</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_fixed_5>
+						<magento_fixed_5>
 							<label>Magento Attribute 5</label>
 							<frontend_type>select</frontend_type>
 							<source_model>contactlab_hub/adminhtml_system_config_source_extraProperties</source_model>
@@ -560,246 +558,242 @@
 							<show_in_default>1</show_in_default>
 							<show_in_website>1</show_in_website>
 							<show_in_store>1</show_in_store>
-	                   	</magento_fixed_5>
-	                   	
-	                   	<hub_variable_1>
-                    		 <label>Hub Attribute 6</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>60</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_variable_1>
-                    	<magento_variable_1>
-                    		 <label>Magento Attribute 6</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>61</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>1</show_in_website>
-                             <show_in_store>1</show_in_store>
-                    	</magento_variable_1>
-                    	<hub_variable_2>
-                    		 <label>Hub Attribute 7</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>70</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_variable_2>
-                    	<magento_variable_2>
-                    		 <label>Magento Attribute 7</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>71</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>1</show_in_website>
-                             <show_in_store>1</show_in_store>
-                    	</magento_variable_2>
-                    	<hub_variable_3>
-                    		 <label>Hub Attribute 8</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>80</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_variable_3>
-                    	<magento_variable_3>
-                    		 <label>Magento Attribute 8</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>81</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>1</show_in_website>
-                             <show_in_store>1</show_in_store>
-                    	</magento_variable_3>
-                    	<hub_variable_4>
-                    		 <label>Hub Attribute 9</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>90</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_variable_4>
-                    	<magento_variable_4>
-                    		 <label>Magento Attribute 9</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>91</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>1</show_in_website>
-                             <show_in_store>1</show_in_store>
-                    	</magento_variable_4>
-                    	<hub_variable_5>
-                    		 <label>Hub Attribute 10</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>100</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>0</show_in_website>
-                             <show_in_store>0</show_in_store>
-                    	</hub_variable_5>
-                    	<magento_variable_5>
-                    		 <label>Magento Attribute 10</label>
-                             <frontend_type>text</frontend_type>
-                             <sort_order>101</sort_order>
-                             <show_in_default>1</show_in_default>
-                             <show_in_website>1</show_in_website>
-                             <show_in_store>1</show_in_store>
-                    	</magento_variable_5>
-                    </fields>
-                </extra_properties>                
-                                   
-                <cron_events translate="label">
-                    <label>Cron Export Events Settings</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>60</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>0</show_in_website>
-                    <show_in_store>0</show_in_store>
-                    <fields>   
-                    	<limit>
-                    		<label>Limit Events to export</label>
-                            <frontend_type>select</frontend_type>
-                        	<source_model>contactlab_hub/adminhtml_system_config_source_cron_eventsLimit</source_model>
-                        	<sort_order>10</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                    	</limit>                                           
-                        <frequency translate="label">
-                            <label>Frequency</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>contactlab_hub/adminhtml_system_config_source_cron_frequency</source_model>
-                            <backend_model>contactlab_hub/adminhtml_system_config_backend_hub_cron_events</backend_model>
-                            <sort_order>20</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </frequency>
-                        <time translate="label">
-                            <label>Start Time</label>
-                            <frontend_type>time</frontend_type>
-                            <sort_order>21</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends>
+						</magento_fixed_5>
+						<hub_variable_1>
+							<label>Hub Attribute 6</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>60</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_variable_1>
+						<magento_variable_1>
+							<label>Magento Attribute 6</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>61</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</magento_variable_1>
+						<hub_variable_2>
+							<label>Hub Attribute 7</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>70</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_variable_2>
+						<magento_variable_2>
+							<label>Magento Attribute 7</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>71</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</magento_variable_2>
+						<hub_variable_3>
+							<label>Hub Attribute 8</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>80</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_variable_3>
+						<magento_variable_3>
+							<label>Magento Attribute 8</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>81</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</magento_variable_3>
+						<hub_variable_4>
+							<label>Hub Attribute 9</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>90</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_variable_4>
+						<magento_variable_4>
+							<label>Magento Attribute 9</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>91</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</magento_variable_4>
+						<hub_variable_5>
+							<label>Hub Attribute 10</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>100</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</hub_variable_5>
+						<magento_variable_5>
+							<label>Magento Attribute 10</label>
+							<frontend_type>text</frontend_type>
+							<sort_order>101</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>1</show_in_store>
+						</magento_variable_5>
+					</fields>
+				</extra_properties>
+				<cron_events translate="label">
+					<label>Cron Export Events Settings</label>
+					<frontend_type>text</frontend_type>
+					<sort_order>60</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>0</show_in_website>
+					<show_in_store>0</show_in_store>
+					<fields>
+						<limit>
+							<label>Limit Events to export</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_eventsLimit</source_model>
+							<sort_order>10</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</limit>
+						<frequency translate="label">
+							<label>Frequency</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_frequency</source_model>
+							<backend_model>contactlab_hub/adminhtml_system_config_backend_hub_cron_events</backend_model>
+							<sort_order>20</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</frequency>
+						<time translate="label">
+							<label>Start Time</label>
+							<frontend_type>time</frontend_type>
+							<sort_order>21</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+							<depends>
 								<frequency separator="|">
-	        						<value>D|W|M</value>
-	    						</frequency>                            	                            
-                            </depends>                            
-                        </time>             
-                        <repeat_minutes>
-                        	<label>Repeats</label>
-                            <frontend_type>select</frontend_type>
-                        	<source_model>contactlab_hub/adminhtml_system_config_source_cron_minutes</source_model>
-                        	<sort_order>22</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends>
-								<frequency>I</frequency>                            	                            
-                            </depends>
-                        </repeat_minutes>
-                        <repeat_hours>
-                        	<label>Repeats</label>
-                            <frontend_type>select</frontend_type>
-                        	<source_model>contactlab_hub/adminhtml_system_config_source_cron_hours</source_model>
-                        	<sort_order>23</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends>
-								<frequency>H</frequency>                            	                            
-                            </depends>
-                        </repeat_hours>                                  
-                    </fields>
-                </cron_events>
-
-                <cron_previous_customers translate="label">
-                    <label>Cron Previous Customers Settings</label>
-                    <frontend_type>text</frontend_type>
-                    <sort_order>70</sort_order>
-                    <show_in_default>1</show_in_default>
-                    <show_in_website>0</show_in_website>
-                    <show_in_store>1</show_in_store>
-                    <fields>     
-                    	 <enabled translate="label">
-                            <label>Enable</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>adminhtml/system_config_source_yesno</source_model>
-                            <sort_order>10</sort_order>
-                            <show_in_default>0</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>1</show_in_store>
-                            <comment>Enable or disable export Previous Customers</comment>
-                        </enabled>                  
-                    	<previous_date>
-                    		<label>Previous Date</label>                    		                    		                            
-                    		<frontend_type>text</frontend_type>
-                        	<frontend_model>contactlab_hub/adminhtml_system_config_source_date</frontend_model>                        	                         	
-                        	<sort_order>20</sort_order>
-                            <show_in_default>0</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>1</show_in_store>
-                    	</previous_date>     
-                    	<limit>
-                    		<label>Limit Customers to export</label>                    		                    		
-                            <frontend_type>select</frontend_type>
-                        	<source_model>contactlab_hub/adminhtml_system_config_source_cron_customersLimit</source_model>                        	 
-                        	<frontend_type>text</frontend_type>
-                        	<sort_order>30</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>       
-                    	</limit>                                           
-                        <frequency translate="label, tooltip">
-                            <label>Frequency</label>
-                            <frontend_type>select</frontend_type>
-                            <source_model>contactlab_hub/adminhtml_system_config_source_cron_frequency</source_model>
-                            <backend_model>contactlab_hub/adminhtml_system_config_backend_hub_cron_previousCustomers</backend_model>                            
-                            <sort_order>40</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                        </frequency>
-                        <time translate="label">
-                            <label>Start Time</label>
-                            <frontend_type>time</frontend_type>
-                            <sort_order>41</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends>                            	
+									<value>D|W|M</value>
+								</frequency>
+							</depends>
+						</time>
+						<repeat_minutes>
+							<label>Repeats</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_minutes</source_model>
+							<sort_order>22</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+							<depends>
+								<frequency>I</frequency>
+							</depends>
+						</repeat_minutes>
+						<repeat_hours>
+							<label>Repeats</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_hours</source_model>
+							<sort_order>23</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+							<depends>
+								<frequency>H</frequency>
+							</depends>
+						</repeat_hours>
+					</fields>
+				</cron_events>
+				<cron_previous_customers translate="label">
+					<label>Cron Previous Customers Settings</label>
+					<frontend_type>text</frontend_type>
+					<sort_order>70</sort_order>
+					<show_in_default>1</show_in_default>
+					<show_in_website>0</show_in_website>
+					<show_in_store>1</show_in_store>
+					<fields>
+						<enabled translate="label">
+							<label>Enable</label>
+							<frontend_type>select</frontend_type>
+							<source_model>adminhtml/system_config_source_yesno</source_model>
+							<sort_order>10</sort_order>
+							<show_in_default>0</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>1</show_in_store>
+							<comment>Enable or disable export Previous Customers</comment>
+						</enabled>
+						<previous_date>
+							<label>Previous Date</label>
+							<frontend_type>text</frontend_type>
+							<frontend_model>contactlab_hub/adminhtml_system_config_source_date</frontend_model>
+							<sort_order>20</sort_order>
+							<show_in_default>0</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>1</show_in_store>
+						</previous_date>
+						<limit>
+							<label>Limit Customers to export</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_customersLimit</source_model>
+							<frontend_type>text</frontend_type>
+							<sort_order>30</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</limit>
+						<frequency translate="label, tooltip">
+							<label>Frequency</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_frequency</source_model>
+							<backend_model>contactlab_hub/adminhtml_system_config_backend_hub_cron_previousCustomers</backend_model>
+							<sort_order>40</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+						</frequency>
+						<time translate="label">
+							<label>Start Time</label>
+							<frontend_type>time</frontend_type>
+							<sort_order>41</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+							<depends>
 								<frequency separator="|">
-	        						<value>D|W|M</value>
-	    						</frequency>                            	                            
-                            </depends>                            
-                        </time>             
-                        <repeat_minutes>
-                        	<label>Repeats</label>
-                            <frontend_type>select</frontend_type>
-                        	<source_model>contactlab_hub/adminhtml_system_config_source_cron_minutes</source_model>
-                        	<sort_order>42</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>0</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends>                            	
-								<frequency>I</frequency>                            	                            
-                            </depends>
-                        </repeat_minutes>
-                        <repeat_hours>
-                        	<label>Repeats</label>
-                            <frontend_type>select</frontend_type>
-                        	<source_model>contactlab_hub/adminhtml_system_config_source_cron_hours</source_model>
-                        	<sort_order>43</sort_order>
-                            <show_in_default>1</show_in_default>
-                            <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
-                            <depends>                            	
-								<frequency>H</frequency>                            	                            
-                            </depends>
-                        </repeat_hours>                          
-                    </fields>                   
-                </cron_previous_customers>
-  
-            </groups>
-        </contactlab_hub>
-    </sections>
+									<value>D|W|M</value>
+								</frequency>
+							</depends>
+						</time>
+						<repeat_minutes>
+							<label>Repeats</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_minutes</source_model>
+							<sort_order>42</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>0</show_in_website>
+							<show_in_store>0</show_in_store>
+							<depends>
+								<frequency>I</frequency>
+							</depends>
+						</repeat_minutes>
+						<repeat_hours>
+							<label>Repeats</label>
+							<frontend_type>select</frontend_type>
+							<source_model>contactlab_hub/adminhtml_system_config_source_cron_hours</source_model>
+							<sort_order>43</sort_order>
+							<show_in_default>1</show_in_default>
+							<show_in_website>1</show_in_website>
+							<show_in_store>0</show_in_store>
+							<depends>
+								<frequency>H</frequency>
+							</depends>
+						</repeat_hours>
+					</fields>
+				</cron_previous_customers>
+			</groups>
+		</contactlab_hub>
+	</sections>
 </config>

--- a/app/code/community/Contactlab/Hub/etc/system.xml
+++ b/app/code/community/Contactlab/Hub/etc/system.xml
@@ -152,8 +152,9 @@
                             <show_in_store>1</show_in_store>
                         </enabled>
 
-						<untrusted_token translate="label">
+						<untrusted_token translate="label comment">
 							<label>Untrusted token</label>
+							<comment>API token for Javascript</comment>
 							<frontend_type>text</frontend_type>
 	                        <sort_order>0</sort_order>
                             <show_in_default>1</show_in_default>
@@ -162,8 +163,7 @@
 							<depends><enabled>1</enabled></depends>
 						</untrusted_token>
 
-						<disclaimer_enabled translate="label">
-							<label>Disclaimer</label>
+						<disclaimer_enabled>
 							<frontend_model>contactlab_hub/adminhtml_system_config_field_readonly</frontend_model>
 	                        <sort_order>0</sort_order>
                             <show_in_default>1</show_in_default>
@@ -172,9 +172,7 @@
 							<depends><enabled>1</enabled></depends>
 						</disclaimer_enabled>
 
-						<disclaimer_disabled translate="label">
-							<label>Disclaimer</label>
-							<value>disabled comment</value>
+						<disclaimer_disabled>
 							<frontend_model>contactlab_hub/adminhtml_system_config_field_readonly</frontend_model>
 	                        <sort_order>0</sort_order>
                             <show_in_default>1</show_in_default>

--- a/app/code/community/Contactlab/Hub/etc/system.xml
+++ b/app/code/community/Contactlab/Hub/etc/system.xml
@@ -134,6 +134,56 @@
                         </logfilename>                        
                     </fields>
                 </settings>
+            <js_tracking translate="label" module="contactlab_hub">
+                    <label>Javascript tracking</label>
+                    <frontend_type>text</frontend_type>
+                    <sort_order>20</sort_order>
+                    <show_in_default>1</show_in_default>
+                    <show_in_website>1</show_in_website>
+                    <show_in_store>1</show_in_store>
+                    <fields>                                     
+                        <enabled translate="label">
+                            <label>Enable JS tracking</label>
+                    		 <frontend_type>select</frontend_type>
+	                    	 <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+                        </enabled>
+
+						<untrusted_token translate="label">
+							<label>Untrusted token</label>
+							<frontend_type>text</frontend_type>
+	                        <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+							<depends><enabled>1</enabled></depends>
+						</untrusted_token>
+
+						<disclaimer_enabled translate="label">
+							<label>Disclaimer</label>
+							<frontend_model>contactlab_hub/adminhtml_system_config_field_readonly</frontend_model>
+	                        <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+							<depends><enabled>1</enabled></depends>
+						</disclaimer_enabled>
+
+						<disclaimer_disabled translate="label">
+							<label>Disclaimer</label>
+							<value>disabled comment</value>
+							<frontend_model>contactlab_hub/adminhtml_system_config_field_readonly</frontend_model>
+	                        <sort_order>0</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <show_in_website>1</show_in_website>
+                            <show_in_store>1</show_in_store>
+							<depends><enabled>0</enabled></depends>
+						</disclaimer_disabled>
+					</fields>
+				</js_tracking>
                 <events translate="label" module="contactlab_hub">
                     <label>Event Settings</label>
                     <frontend_type>text</frontend_type>

--- a/app/code/community/Contactlab/Hub/sql/contactlab_hub_setup/upgrade-1.1.1-1.2.0.php
+++ b/app/code/community/Contactlab/Hub/sql/contactlab_hub_setup/upgrade-1.1.1-1.2.0.php
@@ -1,0 +1,11 @@
+<?php
+$installer = $this;
+$installer->startSetup();
+
+// Event_data is now used to store all the event properties
+$installer->run("
+ALTER TABLE {$installer->getTable("contactlab_hub/event")}
+    CHANGE COLUMN `event_data` `event_data` VARCHAR(2048) CHARACTER SET 'utf8' COLLATE 'utf8_bin' NOT NULL DEFAULT '';
+");
+
+$installer->endSetup();

--- a/modman
+++ b/modman
@@ -1,0 +1,9 @@
+app/code/community/Contactlab/Hub                      app/code/community/Contactlab/Hub
+app/code/community/Contactlab/Hubcommons               app/code/community/Contactlab/Hubcommons
+app/design/adminhtml/default/default/layout/contactlab/*                      app/design/adminhtml/default/default/layout/contactlab
+app/design/adminhtml/default/default/template/contactlab/*                      app/design/adminhtml/default/default/template/contactlab
+app/etc/modules/* app/etc/modules/
+image/* image/
+js/* js/
+lib/* lib/
+skin/adminhtml/default/images/* skin/adminhtml/default/images/

--- a/modman
+++ b/modman
@@ -6,4 +6,4 @@ app/etc/modules/* app/etc/modules/
 image/* image/
 js/* js/
 lib/* lib/
-skin/adminhtml/default/images/* skin/adminhtml/default/images/
+skin/adminhtml/default/default/images/contactlab skin/adminhtml/default/default/images/contactlab


### PR DESCRIPTION
Hello!
This PR adds the following features:
- Enabling/disabling the JS tracking, and doing all the tracking in the backend (using the same cookie name, so it can be enabled/disabled without collateral damages)
- Using a different API token for JS tracking, useful for separating possibly dirty data from the frontend, and let Magento use a trusted token for future ContactHub features
- [Modman](https://github.com/colinmollenhour/modman) file for easier development

Other improvements:
- Prepare the event properties for product-related events _before_ saving the event to DB, when the product data is still in memory 
- Do not save the full formatted event on DB when the export is successful, but only in case of errors
- Fixed [a bug with the removeFromWishlist event](https://github.com/contactlab/contacthub-connect-magento/commit/9ad1364a61e0bd3adb313581d6d59f14031a2e31)
- Fixed some PHP notices

Notes:
The `productViewed` event when tracked by the backend could outrun the event exporter on bigger magento installations. I left a couple placeholder to put a disclaimer/explanation text when using or not using the JS tracking:

https://github.com/top-solution/contacthub-connect-magento/blob/master/app/code/community/Contactlab/Hub/etc/config.xml#L319

https://github.com/top-solution/contacthub-connect-magento/blob/master/app/code/community/Contactlab/Hub/etc/config.xml#L320
