### PR TITLE
Fix warning on Contactlab_Hub_Model_Adminhtml_System_Config_Backend_Map_Customer and Contactlab_Hub_Helper_Data

### DIFF
--- a/app/code/community/Contactlab/Hub/Model/Adminhtml/System/Config/Backend/Map/Customer.php
+++ b/app/code/community/Contactlab/Hub/Model/Adminhtml/System/Config/Backend/Map/Customer.php
@@ -12,7 +12,7 @@ class Contactlab_Hub_Model_Adminhtml_System_Config_Backend_Map_Customer
     {
         $_value = $this->getValue();
         unset($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE][-1]);
-        $startOne = array_combine(range(1, count($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE])),
+        $startOne = @array_combine(range(1, count($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE])),
             array_values($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE]));
         $_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE] = $startOne;
         $this->setValue($_value);

--- a/app/code/community/Contactlab/Hub/Model/Adminhtml/System/Config/Backend/Map/Customer.php
+++ b/app/code/community/Contactlab/Hub/Model/Adminhtml/System/Config/Backend/Map/Customer.php
@@ -12,8 +12,14 @@ class Contactlab_Hub_Model_Adminhtml_System_Config_Backend_Map_Customer
     {
         $_value = $this->getValue();
         unset($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE][-1]);
-        $startOne = @array_combine(range(1, count($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE])),
-            array_values($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE]));
+
+        if(count($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE])){
+            $startOne = array_combine(range(1, count($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE])),
+                array_values($_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE]));
+        }else{
+            $startOne = array();
+        }
+
         $_value[static::XML_PATH_HUB_FIELD_ATTRIBUTE] = $startOne;
         $this->setValue($_value);
         parent::_beforeSave();


### PR DESCRIPTION
Fixes a warning when saving and empty value for the customer_mapping, having 'false' as a value for the customer_mapping attribute also gave a warning on Contactlab_Hub_Helper_Data line 308 that eventually cycled the 'false' value